### PR TITLE
Awesome cobol is probably a joke

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,6 @@
 - [PHP](https://github.com/ziadoz/awesome-php)
 - [Java](https://github.com/akullpp/awesome-java)
 - [Erlang](https://github.com/drobakowski/awesome-erlang)
-- [Cobol](https://github.com/dshimy/awesome-cobol)
 
 ## Miscellaneous
 


### PR DESCRIPTION
It looks like the author copy/pasted the awesome-go repo - removed some stuff and then replaced "go" with "cobol".
