### PR TITLE
Changed link for title-casing resource

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -7,7 +7,7 @@ Please ensure your pull request adheres to the following guidelines:
 - Search previous suggestions before making a new one, as yours may be a duplicate.
 - Make sure the list is useful before submitting. That implies it has enough content and every item has a good succinct description.
 - Make an individual pull request for each suggestion.
-- Titles should be [capitalized](http://grammar.yourdictionary.com/capitalization/rules-for-capitalization-in-titles.html).
+- Use [title-casing](http://titlecapitalization.com) (AP style). 
 - Use the following format: `[List Name](link)`
 - Link additions should be added to the bottom of the relevant category.
 - New categories or improvements to the existing categorization are welcome.


### PR DESCRIPTION
I updated the title-case link to go to http://titlecapitalization.com. Contributors only need to enter the title and it will automatically be title-cased. I use this resource in some of my repos' for contributors and think it will be much more simpler than the previous resource.