### PR TITLE
Adds one line to the "Adding to this list" section

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -20,6 +20,7 @@ Please ensure your pull request adheres to the following guidelines:
 - Check your spelling and grammar.
 - Make sure your text editor is set to remove trailing whitespace.
 - The pull request and commit should have a useful title.
+- The body of your commit message should contain a link to the repository.
 
 Thank you for your suggestions!
 


### PR DESCRIPTION
By browsing through the PRs that we're getting on a daily basis, it seems like it would be easier to request from the people to submit a link directly in the body of the commit message. That way, we can just click on it instead of switching to the `Files` tab, copying it and then pasting it in a new browser tab.

It's just something that came to my mind like right now, so I'm gonna wait for the feedback.