### PR TITLE
Add `Machine Learning Tutorials`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,7 @@ Please read the [contribution guidelines](contributing.md) or the [creating a li
 - [Deep Vision](https://github.com/kjw0612/awesome-deep-vision)
 - [Open Source Society University](https://github.com/open-source-society/computer-science)
 - [Functional Programming](https://github.com/lucasviola/awesome-functional-programming)
+- [Machine Learning Tutorials](https://github.com/ujjwalkarn/Machine-Learning-Tutorials)
 
 
 ## Big Data


### PR DESCRIPTION
I've added a curated list of Machine Learning tutorials which are broken down by topics. My new list (https://github.com/ujjwalkarn/Machine-Learning-Tutorials) is significantly different from the other Machine Learning List (https://github.com/josephmisiti/awesome-machine-learning). My list contains awesome tutorials, articles, code implementations and other resources categorized by Machine Learning Algorithms/Models which is useful for folks trying to learn and understand these and implement them from scratch, while the other list focuses on machine learning frameworks/libraries and software (categorized by languages) but does not provide any tutorial for each model/algorithm. My list is also quite different from the Awesome Data Science List (https://github.com/okulbilisim/awesome-datascience) for to the same reason.