### PR TITLE
Add a travis config to check the links in readme.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.2
+before_script:
+  - gem install awesome_bot
+script:
+  - awesome_bot README.md --allow-redirect

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-redirect
+  - awesome_bot readme.md --allow-redirect


### PR DESCRIPTION
This travis configuration checks all links in readme.md to ensure they're good. It'll make it easier to accept PRs.

You'll still have to go to travis-ci.org and enable travis checking for your fork, but this configuration works for my fork.