### PR TITLE
Replace 'Vim Awesome' with 'Vim Galore'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,7 +215,7 @@ Please read the [contribution guidelines](contributing.md) or the [creating a li
 ## Editors
 
 - [Sublime Text](https://github.com/dreikanter/sublime-bookmarks)
-- [Vim](http://vimawesome.com)
+- [Vim](https://github.com/mhinz/vim-galore)
 - [Emacs](https://github.com/emacs-tw/awesome-emacs)
 - [Atom](https://github.com/mehcode/awesome-atom)
 


### PR DESCRIPTION
https://github.com/mhinz/vim-galore

Why?
[vimawesome.com](http://vimawesome.com) isn't like any of the other awesome lists here. It's just a list of 14072 plugins which nobody would have the time to read through. Vim Galore has a guide, many tips as well as a *selection* of plugins and colour schemes.