### PR TITLE
Adding tips repository to rails category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,7 @@ Check out my [blog](https://blog.sindresorhus.com) and follow me on [Twitter](ht
     - [Education](https://github.com/fukuball/Awesome-Laravel-Education/blob/master/langs/en_US.md)
 - [Rails](https://github.com/ekremkaraca/awesome-rails)
 	- [Gems](https://github.com/hothero/awesome-rails-gem)
+	- [Tips](https://github.com/logeshmallow/rails_tips)
 - [Phalcon](https://github.com/sergeyklay/awesome-phalcon)
 - [Useful `.htaccess` Snippets](https://github.com/phanan/htaccess)
 - [nginx](https://github.com/fcambus/nginx-resources)


### PR DESCRIPTION
Whenever I use to search for a best one and most preferred ones to use, I come down to awesome and check the list available and look into those. By that way I came to see the jstips, which was remarkably useful. So I thought of searching for tips related to rails and there were few but not maintained. So, I thought of making this for rails category too. And I discussed with few more devs and they too felt useful and so I am proposing this.