### PR TITLE
update logo in README to use production rawgit url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 <h1 align="center">
 	<br>
-	<img width="400" src="https://rawgit.com/sindresorhus/awesome/master/media/logo.svg" alt="awesome">
+	<img width="400" src="https://cdn.rawgit.com/sindresorhus/awesome/master/media/logo.svg" alt="awesome">
 	<br>
 	<br>
 	<br>


### PR DESCRIPTION
When I came to the README on github recently, I encountered this:

![image 2016-02-19 at 12 36 19 pm](https://cloud.githubusercontent.com/assets/28044/13183599/a9852c68-d705-11e5-8ba5-74f7bed8a537.png)

It looks like rawgit has made some changes and they've added a production url. The url that was in use was for their dev/test environment that includes the following restrictions:

> * For sharing low-traffic, temporary examples or demos with small numbers of people.
> * Excessive traffic may lead to throttling and blacklisting.