### PR TITLE
Add an '.md' file which attaches repo info (stars, pushed at)

### DIFF
--- a/awesome_with_repo_info.md
+++ b/awesome_with_repo_info.md
@@ -1,0 +1,413 @@
+<img src="https://cdn.rawgit.com/sindresorhus/awesome/master/media/logo.svg" alt="awesome" width="400" />
+=========================================================================================================
+
+> A curated list of awesome lists
+
+-   [What is an awesome list?](awesome.md)
+-   [Contribution guide](contributing.md)
+-   [Creating a list](create-list.md)
+    <sup>Please\\ take\\ the\\ time\\ to\\ read\\ this\\ and\\ do\\ an\\ actual\\ effort\\ with\\ your\\ list.\\ All\\ the\\ low-quality\\ submissions\\ are\\ burning\\ me\\ out...</sup>
+-   [Buy a sticker](https://www.stickermule.com/marketplace/10034-awesome)
+
+[![Awesome chat](https://badges.gitter.im/sindresorhus/awesome.svg)](https://gitter.im/sindresorhus/awesome)
+
+-
+
+Check out my [blog](https://blog.sindresorhus.com) and follow me on [Twitter](https://twitter.com/sindresorhus) .
+
+Table of Contents
+-----------------
+
+-   [Platforms](#platforms)
+-   [Programming Languages](#programming-languages)
+-   [Front-end Development](#front-end-development)
+-   [Back-end Development](#back-end-development)
+-   [Computer Science](#computer-science)
+-   [Big Data](#big-data)
+-   [Theory](#theory)
+-   [Books](#books)
+-   [Editors](#editors)
+-   [Gaming](#gaming)
+-   [Development Environment](#development-environment)
+-   [Entertainment](#entertainment)
+-   [Databases](#databases)
+-   [Media](#media)
+-   [Learn](#learn)
+-   [Security](#security)
+-   [Content Management System](#content-management-system)
+-   [Miscellaneous](#miscellaneous)
+
+Platforms
+---------
+
+-   [Node.js](https://github.com/sindresorhus/awesome-nodejs) <span> | ★ 11184, pushed 1 days ago | </span>
+-   [Frontend Development](https://github.com/dypsilon/frontend-dev-bookmarks) <span> | ★ 18585, pushed 13 days ago | </span>
+-   [iOS](https://github.com/vsouza/awesome-ios) <span> | ★ 10799, pushed 0 days ago | </span>
+-   [Android](https://github.com/JStumpp/awesome-android) <span> | ★ 2263, pushed 3 days ago | </span>
+-   [IoT & Hybrid Apps](https://github.com/weblancaster/awesome-IoT-hybrid) <span> | ★ 184, pushed 74 days ago | </span>
+-   [Electron](https://github.com/sindresorhus/awesome-electron) <span> | ★ 5559, pushed 0 days ago | </span>
+-   [Cordova](https://github.com/busterc/awesome-cordova) <span> | ★ 103, pushed 100 days ago | </span>
+-   [React Native](https://github.com/jondot/awesome-react-native) <span> | ★ 4037, pushed 0 days ago | </span>
+-   [Xamarin](https://github.com/benoitjadinon/awesome-xamarin) <span> | ★ 94, pushed 8 days ago | </span>
+-   [Linux](https://github.com/aleksandar-todorovic/awesome-linux) <span> | ★ 323, pushed 47 days ago | </span>
+    -   [Containers](https://github.com/Friz-zy/awesome-linux-containers) <span> | ★ 83, pushed 31 days ago | </span>
+-   [OS X](https://github.com/iCHAIT/awesome-osx) <span> | ★ 3864, pushed 4 days ago | </span>
+    -   [Command-Line](https://github.com/herrbischoff/awesome-osx-command-line) <span> | ★ 7430, pushed 4 days ago | </span>
+    -   [Screensavers](https://github.com/aharris88/awesome-osx-screensavers) <span> | ★ 175, pushed 9 days ago | </span>
+-   [watchOS](https://github.com/yenchenlin1994/awesome-watchos) <span> | ★ 159, pushed 61 days ago | </span>
+-   [JVM](https://github.com/deephacks/awesome-jvm) <span> | ★ 120, pushed 5 days ago | </span>
+-   [Salesforce](https://github.com/mailtoharshit/awesome-salesforce) <span> | ★ 55, pushed 35 days ago | </span>
+-   [Amazon Web Services](https://github.com/donnemartin/awesome-aws) <span> | ★ 1832, pushed 2 days ago | </span>
+-   [Windows](https://github.com/RiseLedger/awesome-windows) <span> | ★ 60, pushed 38 days ago | </span>
+-   [IPFS](https://github.com/ipfs/awesome-ipfs) <span> | ★ 157, pushed 0 days ago | </span>
+-   [Fuse](https://github.com/vinkla/awesome-fuse) <span> | ★ 107, pushed 4 days ago | </span>
+-   [Heroku](https://github.com/ianstormtaylor/awesome-heroku) <span> | ★ 11, pushed 13 days ago | </span>
+
+Programming Languages
+---------------------
+
+-   [JavaScript](https://github.com/sorrycc/awesome-javascript) <span> | ★ 5773, pushed 3 days ago | </span>
+    -   [Promises](https://github.com/wbinnssmith/awesome-promises) <span> | ★ 564, pushed 19 days ago | </span>
+    -   [Standard Style](https://github.com/feross/awesome-standard) <span> | ★ 118, pushed 4 days ago | </span>
+    -   [Must Watch Talks](https://github.com/bolshchikov/js-must-watch) <span> | ★ 10608, pushed 23 days ago | </span>
+    -   [Tips](https://github.com/loverajoel/jstips) <span> | ★ 9463, pushed 3 days ago | </span>
+    -   [Network Layer](https://github.com/Kikobeats/awesome-network-js) <span> | ★ 215, pushed 30 days ago | </span>
+    -   [Micro npm Packages](https://github.com/parro-it/awesome-micro-npm-packages) <span> | ★ 232, pushed 3 days ago | </span>
+    -   [Mad Science npm Packages](https://github.com/feross/awesome-mad-science) <span> | ★ 446, pushed 54 days ago | </span>
+    -   [Maintenance Modules](https://github.com/maxogden/maintenance-modules) <span> | ★ 228, pushed 89 days ago | </span> *(for npm packages)*
+    -   [npm](https://github.com/sindresorhus/awesome-npm) <span> | ★ 1686, pushed 3 days ago | </span>
+    -   [AVA](https://github.com/sindresorhus/awesome-ava) <span> | ★ 95, pushed 0 days ago | </span> *(Test runner)*
+    -   [ESLint](https://github.com/dustinspecker/awesome-eslint) <span> | ★ 113, pushed 0 days ago | </span>
+-   [Swift](https://github.com/matteocrippa/awesome-swift) <span> | ★ 7765, pushed 0 days ago | </span>
+    -   [Education](https://github.com/hsavit1/Awesome-Swift-Education) <span> | ★ 4431, pushed 8 days ago | </span>
+    -   [Playgrounds](https://github.com/uraimo/Awesome-Swift-Playgrounds) <span> | ★ 397, pushed 6 days ago | </span>
+-   [Python](https://github.com/vinta/awesome-python) <span> | ★ 20041, pushed 0 days ago | </span>
+-   [Rust](https://github.com/kud1ing/awesome-rust) <span> | ★ 2028, pushed 1 days ago | </span>
+-   [Haskell](https://github.com/krispo/awesome-haskell) <span> | ★ 711, pushed 9 days ago | </span>
+-   [PureScript](https://github.com/passy/awesome-purescript) <span> | ★ 57, pushed 56 days ago | </span>
+-   [Go](https://github.com/avelino/awesome-go) <span> | ★ 12248, pushed 0 days ago | </span>
+-   [Scala](https://github.com/lauris/awesome-scala) <span> | ★ 3330, pushed 3 days ago | </span>
+-   [Ruby](https://github.com/markets/awesome-ruby) <span> | ★ 5602, pushed 0 days ago | </span>
+    -   [Ruby Events](https://github.com/planetruby/awesome-events) <span> | ★ 167, pushed 4 days ago | </span> *(Conferences, Meetups, etc.)*
+-   [Clojure](https://github.com/razum2um/awesome-clojure) <span> | ★ 666, pushed 1 days ago | </span>
+-   [ClojureScript](https://github.com/emrehan/awesome-clojurescript) <span> | ★ 241, pushed 27 days ago | </span>
+-   [Elixir](https://github.com/h4cc/awesome-elixir) <span> | ★ 3564, pushed 3 days ago | </span>
+-   [Elm](https://github.com/isRuslan/awesome-elm) <span> | ★ 558, pushed 0 days ago | </span>
+-   [Erlang](https://github.com/drobakowski/awesome-erlang) <span> | ★ 417, pushed 8 days ago | </span>
+-   [Julia](https://github.com/svaksha/Julia.jl) <span> | ★ 320, pushed 0 days ago | </span>
+-   [Lua](https://github.com/LewisJEllis/awesome-lua) <span> | ★ 802, pushed 50 days ago | </span>
+-   [C](https://github.com/aleksandar-todorovic/awesome-c) <span> | ★ 206, pushed 18 days ago | </span>
+-   [C/C++](https://github.com/fffaraz/awesome-cpp) <span> | ★ 4845, pushed 4 days ago | </span>
+-   [R](https://github.com/qinwf/awesome-R) <span> | ★ 1295, pushed 2 days ago | </span>
+-   [D](https://github.com/zhaopuming/awesome-d) <span> | ★ 122, pushed 6 days ago | </span>
+-   [Common Lisp](https://github.com/CodyReichert/awesome-cl) <span> | ★ 273, pushed 0 days ago | </span>
+-   [Perl](https://github.com/hachiojipm/awesome-perl) <span> | ★ 263, pushed 73 days ago | </span>
+-   [Groovy](https://github.com/kdabir/awesome-groovy) <span> | ★ 258, pushed 3 days ago | </span>
+-   [Dart](https://github.com/yissachar/awesome-dart) <span> | ★ 132, pushed 111 days ago | </span>
+-   [Java](https://github.com/akullpp/awesome-java) <span> | ★ 6605, pushed 0 days ago | </span>
+    -   [RxJava](https://github.com/eleventigers/awesome-rxjava) <span> | ★ 23, pushed 18 days ago | </span>
+-   [Kotlin](https://github.com/JavaBy/awesome-kotlin)
+-   [OCaml](https://github.com/rizo/awesome-ocaml) <span> | ★ 595, pushed 16 days ago | </span>
+-   [Coldfusion](https://github.com/seancoyne/awesome-coldfusion) <span> | ★ 29, pushed 91 days ago | </span>
+-   [Fortran](https://github.com/rabbiabram/awesome-fortran) <span> | ★ 64, pushed 95 days ago | </span>
+-   [.NET](https://github.com/quozd/awesome-dotnet) <span> | ★ 1680, pushed 7 days ago | </span>
+-   [PHP](https://github.com/ziadoz/awesome-php) <span> | ★ 11501, pushed 5 days ago | </span>
+-   [Delphi](https://github.com/Fr0sT-Brutal/awesome-delphi) <span> | ★ 122, pushed 73 days ago | </span>
+-   [Assembler](https://github.com/mat0thew/awesome-asm)
+-   [AutoHotkey](https://github.com/ahkscript/awesome-AutoHotkey) <span> | ★ 225, pushed 11 days ago | </span>
+-   [AutoIt](https://github.com/J2TeaM/awesome-AutoIt) <span> | ★ 32, pushed 46 days ago | </span>
+-   [Crystal](https://github.com/veelenga/awesome-crystal) <span> | ★ 296, pushed 4 days ago | </span>
+-   [TypeScript](https://github.com/dzharii/awesome-typescript) <span> | ★ 99, pushed 49 days ago | </span>
+
+Front-end Development
+---------------------
+
+-   [ES6 Tools](https://github.com/addyosmani/es6-tools) <span> | ★ 2972, pushed 51 days ago | </span>
+-   [Web Performance Optimization](https://github.com/davidsonfellipe/awesome-wpo) <span> | ★ 5349, pushed 1 days ago | </span>
+-   [Web Tools](https://github.com/lvwzhen/tools) <span> | ★ 188, pushed 49 days ago | </span>
+-   [CSS](https://github.com/sotayamashita/awesome-css) <span> | ★ 398, pushed 0 days ago | </span>
+    -   [Critical-Path (Above-the-fold) Tools](https://github.com/addyosmani/critical-path-css-tools) <span> | ★ 571, pushed 51 days ago | </span>
+    -   [Scalability](https://github.com/davidtheclark/scalable-css-reading-list) <span> | ★ 1015, pushed 14 days ago | </span>
+    -   [Must-Watch Talks](https://github.com/AllThingsSmitty/must-watch-css) <span> | ★ 1992, pushed 48 days ago | </span>
+    -   [Protips](https://github.com/AllThingsSmitty/css-protips) <span> | ★ 6685, pushed 6 days ago | </span>
+-   [React](https://github.com/enaqx/awesome-react) <span> | ★ 12954, pushed 1 days ago | </span>
+    -   [Relay](https://github.com/expede/awesome-relay) <span> | ★ 59, pushed 33 days ago | </span>
+-   [Web Components](https://github.com/mateusortiz/webcomponents-the-right-way) <span> | ★ 792, pushed 156 days ago | </span>
+-   [Polymer](https://github.com/Granze/awesome-polymer) <span> | ★ 206, pushed 25 days ago | </span>
+-   [Angular 2](https://github.com/AngularClass/awesome-angular2) <span> | ★ 1365, pushed 1 days ago | </span>
+-   [Angular](https://github.com/gianarb/awesome-angularjs) <span> | ★ 1457, pushed 0 days ago | </span>
+-   [Backbone](https://github.com/sadcitizen/awesome-backbone) <span> | ★ 316, pushed 22 days ago | </span>
+-   [HTML5](https://github.com/diegocard/awesome-html5) <span> | ★ 468, pushed 61 days ago | </span>
+-   [SVG](https://github.com/willianjusten/awesome-svg) <span> | ★ 2849, pushed 2 days ago | </span>
+-   [Canvas](https://github.com/raphamorim/awesome-canvas) <span> | ★ 92, pushed 59 days ago | </span>
+-   [KnockoutJS](https://github.com/dnbard/awesome-knockout) <span> | ★ 36, pushed 40 days ago | </span>
+-   [Dojo Toolkit](https://github.com/peterkokot/awesome-dojo) <span> | ★ 46, pushed 122 days ago | </span>
+-   [Inspiration](https://github.com/NoahBuscher/Inspire) <span> | ★ 370, pushed 131 days ago | </span>
+-   [Ember](https://github.com/nmec/awesome-ember) <span> | ★ 123, pushed 2 days ago | </span>
+-   [Android UI](https://github.com/wasabeef/awesome-android-ui) <span> | ★ 13627, pushed 13 days ago | </span>
+-   [iOS UI](https://github.com/cjwirth/awesome-ios-ui) <span> | ★ 7817, pushed 30 days ago | </span>
+-   [Meteor](https://github.com/Urigo/awesome-meteor) <span> | ★ 537, pushed 15 days ago | </span>
+-   [BEM](https://github.com/sturobson/BEM-resources) <span> | ★ 143, pushed 16 days ago | </span>
+-   [Flexbox](https://github.com/afonsopacifer/awesome-flexbox) <span> | ★ 325, pushed 4 days ago | </span>
+-   [Web Typography](https://github.com/deanhume/typography) <span> | ★ 142, pushed 33 days ago | </span>
+-   [Web Accessibility](https://github.com/brunopulis/awesome-a11y) <span> | ★ 123, pushed 7 days ago | </span>
+-   [Material Design](https://github.com/sachin1092/awesome-material) <span> | ★ 332, pushed 88 days ago | </span>
+-   [D3](https://github.com/wbkd/awesome-d3) <span> | ★ 2765, pushed 13 days ago | </span>
+-   [Emails](https://github.com/jonathandion/awesome-emails) <span> | ★ 73, pushed 12 days ago | </span>
+-   [jQuery](https://github.com/peterkokot/awesome-jquery) <span> | ★ 184, pushed 16 days ago | </span>
+    -   [Tips](https://github.com/AllThingsSmitty/jquery-tips-everyone-should-know) <span> | ★ 3676, pushed 39 days ago | </span>
+-   [Web Audio](https://github.com/notthetup/awesome-webaudio) <span> | ★ 147, pushed 8 days ago | </span>
+-   [Offline-First](https://github.com/pazguille/offline-first) <span> | ★ 1384, pushed 29 days ago | </span>
+-   [Static Website Services](https://github.com/aharris88/awesome-static-website-services) <span> | ★ 170, pushed 4 days ago | </span>
+-   [A-Frame VR](https://github.com/aframevr/awesome-aframe) <span> | ★ 203, pushed 7 days ago | </span> *(Virtual reality)*
+-   [Cycle.js](https://github.com/vic/awesome-cyclejs) <span> | ★ 302, pushed 4 days ago | </span>
+-   [Text Editing](https://github.com/dok/awesome-text-editing) <span> | ★ 7, pushed 40 days ago | </span>
+-   [Motion UI Design](https://github.com/fliptheweb/motion-ui-design) <span> | ★ 222, pushed 18 days ago | </span>
+-   [Vue.js](https://github.com/vuejs/awesome-vue) <span> | ★ 2062, pushed 1 days ago | </span>
+-   [Marionette.js](https://github.com/sadcitizen/awesome-marionette) <span> | ★ 101, pushed 10 days ago | </span>
+-   [Aurelia](https://github.com/behzad888/awesome-aurelia) <span> | ★ 14, pushed 0 days ago | </span>
+-   [Charting](https://github.com/zingchart/awesome-charting) <span> | ★ 555, pushed 14 days ago | </span>
+-   [Ionic Framework 2](https://github.com/candelibas/awesome-ionic2) <span> | ★ 46, pushed 0 days ago | </span>
+-   [Chrome DevTools](https://github.com/ChromeDevTools/awesome-chrome-devtools) <span> | ★ 1305, pushed 3 days ago | </span>
+
+Back-end Development
+--------------------
+
+-   [Django](https://github.com/rosarior/awesome-django) <span> | ★ 3590, pushed 10 days ago | </span>
+-   [Flask](https://github.com/humiaozuzu/awesome-flask) <span> | ★ 2264, pushed 4 days ago | </span>
+-   [Docker](https://github.com/veggiemonk/awesome-docker) <span> | ★ 3019, pushed 0 days ago | </span>
+-   [Vagrant](https://github.com/iJackUA/awesome-vagrant) <span> | ★ 175, pushed 53 days ago | </span>
+-   [Pyramid](https://github.com/uralbash/awesome-pyramid) <span> | ★ 240, pushed 33 days ago | </span>
+-   [Play1 Framework](https://github.com/PerfectCarl/awesome-play1) <span> | ★ 22, pushed 98 days ago | </span>
+-   [CakePHP](https://github.com/friendsofcake/awesome-cakephp) <span> | ★ 388, pushed 5 days ago | </span>
+-   [Symfony](https://github.com/sitepoint/awesome-symfony) <span> | ★ 681, pushed 33 days ago | </span>
+    -   [Education](https://github.com/Symfonisti/awesome-symfony-education) <span> | ★ 128, pushed 36 days ago | </span>
+-   [Laravel](https://github.com/chiraggude/awesome-laravel) <span> | ★ 2657, pushed 7 days ago | </span>
+    -   [Education](https://github.com/fukuball/Awesome-Laravel-Education/blob/master/langs/en_US.md)
+-   [Rails](https://github.com/ekremkaraca/awesome-rails) <span> | ★ 813, pushed 32 days ago | </span>
+    -   [Gems](https://github.com/hothero/awesome-rails-gem) <span> | ★ 1604, pushed 18 days ago | </span>
+-   [Phalcon](https://github.com/sergeyklay/awesome-phalcon) <span> | ★ 171, pushed 16 days ago | </span>
+-   [Useful `     .htaccess    ` Snippets](https://github.com/phanan/htaccess) <span> | ★ 9193, pushed 12 days ago | </span>
+-   [nginx](https://github.com/fcambus/nginx-resources) <span> | ★ 1615, pushed 51 days ago | </span>
+-   [Dropwizard](https://github.com/stve/awesome-dropwizard) <span> | ★ 11, pushed 3 days ago | </span>
+-   [Kubernetes](https://github.com/ramitsurana/awesome-kubernetes) <span> | ★ 132, pushed 11 days ago | </span>
+-   [Lumen](https://github.com/unicodeveloper/awesome-lumen) <span> | ★ 56, pushed 22 days ago | </span>
+
+Computer Science
+----------------
+
+-   [University Courses](https://github.com/prakhar1989/awesome-courses) <span> | ★ 14808, pushed 6 days ago | </span>
+-   [Data Science](https://github.com/okulbilisim/awesome-datascience) <span> | ★ 2293, pushed 0 days ago | </span>
+-   [Machine Learning](https://github.com/josephmisiti/awesome-machine-learning) <span> | ★ 12376, pushed 2 days ago | </span>
+    -   [Tutorials](https://github.com/ujjwalkarn/Machine-Learning-Tutorials) <span> | ★ 2178, pushed 64 days ago | </span>
+-   [Speech and Natural Language Processing](https://github.com/edobashira/speech-language-processing) <span> | ★ 1186, pushed 91 days ago | </span>
+    -   [Spanish](https://github.com/dav009/awesome-spanish-nlp) <span> | ★ 45, pushed 130 days ago | </span>
+-   [Linguistics](https://github.com/theimpossibleastronaut/awesome-linguistics) <span> | ★ 39, pushed 255 days ago | </span>
+-   [Cryptography](https://github.com/MaciejCzyzewski/retter) <span> | ★ 1539, pushed 176 days ago | </span>
+-   [Computer Vision](https://github.com/jbhuang0604/awesome-computer-vision) <span> | ★ 1224, pushed 31 days ago | </span>
+-   [Deep Learning](https://github.com/ChristosChristofidis/awesome-deep-learning) <span> | ★ 1840, pushed 36 days ago | </span> *(Neural networks)*
+-   [Deep Vision](https://github.com/kjw0612/awesome-deep-vision) <span> | ★ 1150, pushed 19 days ago | </span>
+-   [Open Source Society University](https://github.com/open-source-society/computer-science) <span> | ★ 13563, pushed 0 days ago | </span>
+-   [Functional Programming](https://github.com/lucasviola/awesome-functional-programming) <span> | ★ 114, pushed 49 days ago | </span>
+-   [Static Analysis & Code Quality](https://github.com/mre/awesome-static-analysis) <span> | ★ 68, pushed 10 days ago | </span>
+-   [Software-Defined Networking](https://github.com/sdnds-tw/awesome-sdn) <span> | ★ 18, pushed 33 days ago | </span>
+
+Big Data
+--------
+
+-   [Big Data](https://github.com/onurakpolat/awesome-bigdata) <span> | ★ 3065, pushed 11 days ago | </span>
+-   [Public Datasets](https://github.com/caesar0301/awesome-public-datasets) <span> | ★ 13760, pushed 3 days ago | </span>
+-   [Hadoop](https://github.com/youngwookim/awesome-hadoop) <span> | ★ 320, pushed 55 days ago | </span>
+-   [Data Engineering](https://github.com/igorbarinov/awesome-data-engineering) <span> | ★ 450, pushed 9 days ago | </span>
+-   [Streaming](https://github.com/manuzhang/awesome-streaming) <span> | ★ 42, pushed 10 days ago | </span>
+
+Theory
+------
+
+-   [Papers We Love](https://github.com/papers-we-love/papers-we-love) <span> | ★ 16056, pushed 4 days ago | </span>
+-   [Talks](https://github.com/JanVanRyswyck/awesome-talks) <span> | ★ 1150, pushed 8 days ago | </span>
+-   [Algorithms](https://github.com/tayllan/awesome-algorithms) <span> | ★ 1389, pushed 30 days ago | </span>
+-   [Algorithm Visualizations](https://github.com/enjalot/algovis) <span> | ★ 488, pushed 78 days ago | </span>
+-   [Artificial Intelligence](https://github.com/owainlewis/awesome-artificial-intelligence) <span> | ★ 1493, pushed 12 days ago | </span>
+-   [Search Engine Optimization](https://github.com/marcobiedermann/search-engine-optimization) <span> | ★ 214, pushed 50 days ago | </span>
+-   [Competitive Programming](https://github.com/lnishan/awesome-competitive-programming) <span> | ★ 132, pushed 12 days ago | </span>
+-   [Math](https://github.com/rossant/awesome-math) <span> | ★ 130, pushed 7 days ago | </span>
+
+Books
+-----
+
+-   [Free Programming Books](https://github.com/vhf/free-programming-books) <span> | ★ 53940, pushed 0 days ago | </span>
+-   [Free Software Testing Books](https://github.com/ligurio/free-software-testing-books/blob/master/free-software-testing-books.md)
+-   [Go Books](https://github.com/dariubs/GoBooks) <span> | ★ 2043, pushed 24 days ago | </span>
+-   [R Books](https://github.com/RomanTsegelskyi/rbooks) <span> | ★ 27, pushed 6 days ago | </span>
+-   [Mind Expanding Books](https://github.com/hackerkid/Mind-Expanding-Books) <span> | ★ 331, pushed 3 days ago | </span>
+
+Editors
+-------
+
+-   [Sublime Text](https://github.com/dreikanter/sublime-bookmarks) <span> | ★ 374, pushed 66 days ago | </span>
+-   [Vim](https://github.com/mhinz/vim-galore) <span> | ★ 4604, pushed 16 days ago | </span>
+-   [Emacs](https://github.com/emacs-tw/awesome-emacs) <span> | ★ 1731, pushed 0 days ago | </span>
+-   [Atom](https://github.com/mehcode/awesome-atom) <span> | ★ 306, pushed 46 days ago | </span>
+-   [Visual Studio Code](https://github.com/viatsko/awesome-vscode) <span> | ★ 85, pushed 58 days ago | </span>
+
+Gaming
+------
+
+-   [Game Development](https://github.com/ellisonleao/magictools) <span> | ★ 2852, pushed 24 days ago | </span>
+-   [Game Talks](https://github.com/hzoo/awesome-gametalks) <span> | ★ 269, pushed 19 days ago | </span>
+-   [Godot](https://github.com/Calinou/awesome-godot) <span> | ★ 124, pushed 7 days ago | </span> *(Game engine)*
+-   [Open Source Games](https://github.com/leereilly/games) <span> | ★ 2555, pushed 3 days ago | </span>
+-   [Unity](https://github.com/RyanNielson/awesome-unity) <span> | ★ 524, pushed 4 days ago | </span> *(Game engine)*
+-   [Chess](https://github.com/hkirat/awesome-chess) <span> | ★ 18, pushed 20 days ago | </span>
+-   [LÖVE](https://github.com/JanWerder/awesome-love2d) *(Game engine)*
+-   [PICO-8](https://github.com/felipebueno/awesome-PICO-8) <span> | ★ 83, pushed 18 days ago | </span> *(Fantasy console)*
+
+Development Environment
+-----------------------
+
+-   [Quick Look Plugins](https://github.com/sindresorhus/quick-look-plugins) <span> | ★ 5887, pushed 48 days ago | </span>
+-   [Dev Env](https://github.com/jondot/awesome-devenv) <span> | ★ 380, pushed 97 days ago | </span>
+-   [Dotfiles](https://github.com/webpro/awesome-dotfiles) <span> | ★ 1032, pushed 51 days ago | </span>
+-   [Shell](https://github.com/alebcay/awesome-shell) <span> | ★ 6604, pushed 2 days ago | </span>
+-   [Command-Line Apps](https://github.com/aharris88/awesome-cli-apps) <span> | ★ 384, pushed 6 days ago | </span>
+-   [ZSH Plugins](https://github.com/unixorn/awesome-zsh-plugins) <span> | ★ 1420, pushed 1 days ago | </span>
+-   [GitHub](https://github.com/phillipadsmith/awesome-github) <span> | ★ 183, pushed 29 days ago | </span>
+    -   [Browser Extensions](https://github.com/stefanbuck/awesome-browser-extensions-for-github) <span> | ★ 441, pushed 9 days ago | </span>
+    -   [Cheat Sheet](https://github.com/tiimgreen/github-cheat-sheet) <span> | ★ 18418, pushed 12 days ago | </span>
+-   [Git Cheat Sheet & Git Flow](https://github.com/arslanbilal/git-cheat-sheet) <span> | ★ 1133, pushed 35 days ago | </span>
+-   [Git Tips](https://github.com/git-tips/tips) <span> | ★ 497, pushed 0 days ago | </span>
+-   [Git Add-ons](https://github.com/stevemao/awesome-git-addons) <span> | ★ 221, pushed 37 days ago | </span>
+-   [SSH](https://github.com/moul/awesome-ssh) <span> | ★ 312, pushed 31 days ago | </span>
+-   [FOSS for Developers](https://github.com/httpsGithubParty/FOSS-for-Dev) <span> | ★ 113, pushed 39 days ago | </span>
+
+Entertainment
+-------------
+
+-   [Science Fiction](https://github.com/sindresorhus/awesome-scifi) <span> | ★ 991, pushed 48 days ago | </span> *(Scifi)*
+-   [Fantasy](https://github.com/RichardLitt/awesome-fantasy) <span> | ★ 168, pushed 59 days ago | </span>
+-   [Podcasts](https://github.com/guipdutra/awesome-geek-podcasts) <span> | ★ 588, pushed 0 days ago | </span>
+-   [Email Newsletters](https://github.com/vredniy/awesome-newsletters) <span> | ★ 289, pushed 5 days ago | </span>
+
+Databases
+---------
+
+-   [Database](https://github.com/numetriclabz/awesome-db) <span> | ★ 201, pushed 15 days ago | </span>
+-   [MySQL](https://github.com/shlomi-noach/awesome-mysql/blob/gh-pages/index.md)
+-   [SQLAlchemy](https://github.com/dahlia/awesome-sqlalchemy) <span> | ★ 1086, pushed 15 days ago | </span>
+-   [InfluxDB](https://github.com/mark-rushakoff/awesome-influxdb) <span> | ★ 93, pushed 9 days ago | </span>
+-   [Neo4j](https://github.com/Neueda4j/awesome-neo4j) <span> | ★ 69, pushed 49 days ago | </span>
+-   [Doctrine](https://github.com/TomasVotruba/awesome-doctrine) <span> | ★ 86, pushed 7 days ago | </span> *(PHP ORM)*
+-   [MongoDB](https://github.com/ramnes/awesome-mongodb) <span> | ★ 167, pushed 18 days ago | </span>
+
+Media
+-----
+
+-   [Creative Commons Media](https://github.com/shime/creative-commons-media) <span> | ★ 106, pushed 87 days ago | </span>
+-   [Fonts](https://github.com/brabadu/awesome-fonts) <span> | ★ 110, pushed 32 days ago | </span>
+-   [Codeface](https://github.com/chrissimpkins/codeface) <span> | ★ 3086, pushed 13 days ago | </span> *(Text editor fonts)*
+-   [Stock Resources](https://github.com/neutraltone/awesome-stock-resources) <span> | ★ 5158, pushed 8 days ago | </span>
+-   [GIF](https://github.com/ibaaj/awesome-gif) <span> | ★ 86, pushed 68 days ago | </span>
+-   [Music](https://github.com/ciconia/awesome-music) <span> | ★ 82, pushed 23 days ago | </span>
+-   [Open Source Documents](https://github.com/nacyot/awesome-opensource-documents)
+
+Learn
+-----
+
+-   [CLI Workshoppers/Adventures](https://github.com/therebelrobot/awesome-workshopper) <span> | ★ 126, pushed 73 days ago | </span>
+-   [Learn to Program](https://github.com/karlhorky/learn-to-program) <span> | ★ 168, pushed 60 days ago | </span>
+-   [Speaking](https://github.com/matteofigus/awesome-speaking) <span> | ★ 354, pushed 97 days ago | </span>
+-   [Tech Videos](https://github.com/lucasviola/awesome-tech-videos) <span> | ★ 115, pushed 100 days ago | </span>
+-   [Dive into Machine Learning](https://github.com/hangtwenty/dive-into-machine-learning) <span> | ★ 5094, pushed 6 days ago | </span>
+-   [Computer History](https://github.com/watson/awesome-computer-history) <span> | ★ 576, pushed 6 days ago | </span>
+
+Security
+--------
+
+-   [Application Security](https://github.com/paragonie/awesome-appsec) <span> | ★ 1645, pushed 8 days ago | </span>
+-   [Security](https://github.com/sbilly/awesome-security) <span> | ★ 507, pushed 34 days ago | </span>
+-   [CTF](https://github.com/apsdehal/awesome-ctf) <span> | ★ 412, pushed 19 days ago | </span> *(Capture the Flag)*
+-   [Malware Analysis](https://github.com/rshipp/awesome-malware-analysis) <span> | ★ 936, pushed 1 days ago | </span>
+-   [Android Security](https://github.com/ashishb/android-security-awesome) <span> | ★ 990, pushed 8 days ago | </span>
+-   [Hacking](https://github.com/carpedm20/awesome-hacking) <span> | ★ 490, pushed 35 days ago | </span>
+-   [Honeypots](https://github.com/paralax/awesome-honeypots) <span> | ★ 589, pushed 32 days ago | </span>
+-   [Incident Response](https://github.com/meirwah/awesome-incident-response) <span> | ★ 461, pushed 27 days ago | </span>
+
+Content Management System
+-------------------------
+
+-   [Umbraco](https://github.com/leekelleher/awesome-umbraco) <span> | ★ 51, pushed 52 days ago | </span>
+-   [Refinery CMS](https://github.com/refinerycms-contrib/awesome-refinerycms) <span> | ★ 10, pushed 11 days ago | </span>
+
+Miscellaneous
+-------------
+
+-   [JSON](https://github.com/burningtree/awesome-json) <span> | ★ 299, pushed 10 days ago | </span>
+-   [Discounts for Student Developers](https://github.com/najela/discount-for-student-dev)
+-   [Slack](https://github.com/matiassingers/awesome-slack) <span> | ★ 212, pushed 89 days ago | </span>
+    -   [Communities](https://github.com/filipelinhares/awesome-slack) <span> | ★ 133, pushed 33 days ago | </span>
+-   [Conferences](https://github.com/RichardLitt/awesome-conferences) <span> | ★ 400, pushed 19 days ago | </span>
+-   [GeoJSON](https://github.com/tmcw/awesome-geojson) <span> | ★ 265, pushed 51 days ago | </span>
+-   [Sysadmin](https://github.com/n1trux/awesome-sysadmin) <span> | ★ 3446, pushed 1 days ago | </span>
+-   [Radio](https://github.com/kyleterry/awesome-radio) <span> | ★ 73, pushed 255 days ago | </span>
+-   [Awesome](https://github.com/sindresorhus/awesome) <span> | ★ 33916, pushed 1 days ago | </span>
+-   [Analytics](https://github.com/onurakpolat/awesome-analytics) <span> | ★ 322, pushed 22 days ago | </span>
+-   [Open Companies](https://github.com/opencompany/awesome-open-company) <span> | ★ 90, pushed 104 days ago | </span>
+-   [REST](https://github.com/marmelab/awesome-rest) <span> | ★ 612, pushed 52 days ago | </span>
+-   [Selenium](https://github.com/christian-bromann/awesome-selenium) <span> | ★ 97, pushed 13 days ago | </span>
+-   [Endangered Languages](https://github.com/RichardLitt/endangered-languages) <span> | ★ 78, pushed 23 days ago | </span>
+-   [Continuous Delivery](https://github.com/ciandcd/awesome-ciandcd) <span> | ★ 155, pushed 25 days ago | </span>
+-   [Services Engineering](https://github.com/mmcgrana/services-engineering) <span> | ★ 2050, pushed 255 days ago | </span>
+-   [Free for Developers](https://github.com/ripienaar/free-for-dev) <span> | ★ 13016, pushed 2 days ago | </span>
+-   [Bitcoin](https://github.com/igorbarinov/awesome-bitcoin/)
+-   [Answers](https://github.com/jugoncalves/awesome-answers) *(Stack Overflow, Quora, etc)*
+-   [Sketch](https://github.com/diessica/awesome-sketch) <span> | ★ 404, pushed 157 days ago | </span> *(OS X app)*
+-   [Places to Post Your Startup](https://github.com/mmccaff/PlacesToPostYourStartup) <span> | ★ 847, pushed 84 days ago | </span>
+-   [PCAPTools](https://github.com/caesar0301/awesome-pcaptools) <span> | ★ 365, pushed 3 days ago | </span>
+-   [Remote Jobs](https://github.com/lukasz-madon/awesome-remote-job) <span> | ★ 5348, pushed 0 days ago | </span>
+-   [Boilerplate Projects](https://github.com/melvin0008/awesome-projects-boilerplates) <span> | ★ 193, pushed 55 days ago | </span>
+-   [Readme](https://github.com/matiassingers/awesome-readme) <span> | ★ 344, pushed 26 days ago | </span>
+-   [Tools](https://github.com/cjbarber/ToolsOfTheTrade) <span> | ★ 6259, pushed 0 days ago | </span>
+-   [Styleguides](https://github.com/RichardLitt/awesome-styleguides) <span> | ★ 284, pushed 6 days ago | </span>
+-   [Design and Development Guides](https://github.com/NARKOZ/guides) <span> | ★ 1088, pushed 21 days ago | </span>
+-   [Software Engineering Blogs](https://github.com/kilimchoi/engineering-blogs) <span> | ★ 7723, pushed 0 days ago | </span>
+-   [Self Hosted](https://github.com/Kickball/awesome-selfhosted) <span> | ★ 6676, pushed 2 days ago | </span>
+-   [FOSS Production Apps](https://github.com/jwaterfaucett/awesome-foss-apps) <span> | ★ 82, pushed 142 days ago | </span>
+-   [Gulp](https://github.com/alferov/awesome-gulp) <span> | ★ 134, pushed 29 days ago | </span>
+-   [AMA](https://github.com/sindresorhus/amas) <span> | ★ 513, pushed 2 days ago | </span> *(Ask Me Anything)*
+    -   [Answers](https://github.com/stoeffel/awesome-ama-answers) <span> | ★ 85, pushed 209 days ago | </span>
+-   [Open Source Photography](https://github.com/ibaaj/awesome-OpenSourcePhotography/)
+-   [OpenGL](https://github.com/eug/awesome-opengl) <span> | ★ 264, pushed 8 days ago | </span>
+-   [Productivity](https://github.com/jyguyomarch/awesome-productivity) <span> | ★ 66, pushed 97 days ago | </span>
+-   [GraphQL](https://github.com/chentsulin/awesome-graphql) <span> | ★ 1113, pushed 0 days ago | </span>
+-   [Transit](https://github.com/luqmaan/awesome-transit) <span> | ★ 87, pushed 7 days ago | </span>
+-   [Research Tools](https://github.com/emptymalei/awesome-research) <span> | ★ 92, pushed 17 days ago | </span>
+-   [Niche Job Boards](https://github.com/wfhio/awesome-job-boards) <span> | ★ 29, pushed 19 days ago | </span>
+-   [Data Visualization](https://github.com/fasouto/awesome-dataviz) <span> | ★ 421, pushed 28 days ago | </span>
+-   [Social Media Share Links](https://github.com/vinkla/share-links)
+-   [JSON Datasets](https://github.com/jdorfman/awesome-json-datasets) <span> | ★ 83, pushed 126 days ago | </span>
+-   [Microservices](https://github.com/mfornos/awesome-microservices) <span> | ★ 830, pushed 1 days ago | </span>
+-   [Unicode Code Points](https://github.com/Codepoints/awesome-codepoints) <span> | ★ 80, pushed 62 days ago | </span>
+-   [Internet of Things](https://github.com/HQarroum/awesome-iot) <span> | ★ 205, pushed 58 days ago | </span>
+-   [Beginner-Friendly Projects](https://github.com/MunGell/awesome-for-beginners) <span> | ★ 294, pushed 10 days ago | </span>
+-   [Bluetooth Beacons](https://github.com/beaconinside/awesome-beacon) <span> | ★ 128, pushed 41 days ago | </span>
+-   [Programming Interviews](https://github.com/MaximAbramchuck/awesome-interviews) <span> | ★ 9026, pushed 23 days ago | </span>
+-   [Ripple](https://github.com/vhpoet/awesome-ripple) <span> | ★ 32, pushed 87 days ago | </span> *(Open-source distributed settlement network)*
+-   [Katas](https://github.com/gmontalvoriv/awesome-katas) <span> | ★ 26, pushed 59 days ago | </span>
+-   [Tools for Activism](https://github.com/drewrwilson/toolsforactivism) <span> | ★ 139, pushed 69 days ago | </span>
+-   [TAP](https://github.com/sindresorhus/awesome-tap) <span> | ★ 194, pushed 31 days ago | </span> *(Test Anything Protocol)*
+-   [Robotics](https://github.com/Kiloreux/awesome-robotics) <span> | ★ 160, pushed 13 days ago | </span>
+-   [MQTT](https://github.com/hobbyquaker/awesome-mqtt) <span> | ★ 36, pushed 15 days ago | </span> *(an "Internet of Things" connectivity protocol)*
+-   [Hacking Spots](https://github.com/diasdavid/awesome-hacking-spots) <span> | ★ 242, pushed 1 days ago | </span>
+-   [For Girls](https://github.com/cristianoliveira/awesome4girls) <span> | ★ 93, pushed 34 days ago | </span>
+-   [Vorpal](https://github.com/vorpaljs/awesome-vorpal) <span> | ★ 54, pushed 10 days ago | </span> *(Node.js CLI framework)*
+-   [OKR Methodology](https://github.com/domenicosolazzo/awesome-okr) <span> | ★ 29, pushed 73 days ago | </span> *(Goal setting & communication best practices)*
+-   [Vulkan](https://github.com/vinjn/awesome-vulkan) <span> | ★ 180, pushed 0 days ago | </span>
+-   [LaTeX](https://github.com/egeerardyn/awesome-LaTeX) <span> | ★ 17, pushed 13 days ago | </span> *(Typesetting language)*
+
+License
+-------
+
+[![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
+
+To the extent possible under law, [Sindre Sorhus](http://sindresorhus.com) has waived all copyright and related or neighboring rights to this work.


### PR DESCRIPTION
I collected all the GitHub repositories info from README.md via GitHub API, and attached the number of stars and last pushed at for each curated item. It is intended for users to quickly get some basic info of repositories instead of clicking on each. The data was collected today, and I can update the .md file regularly or as needed.

The format above TOC is a little off, which I think was caused by generating GitHub flavored markdown with pandoc.

