### PR TITLE
Add Serverless Framework

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,7 @@ Check out my [blog](https://blog.sindresorhus.com) and follow me on [Twitter](ht
 - [Dropwizard](https://github.com/stve/awesome-dropwizard)
 - [Kubernetes](https://github.com/ramitsurana/awesome-kubernetes)
 - [Lumen](https://github.com/unicodeveloper/awesome-lumen)
+- [Serverless Framework](https://github.com/JustServerless/awesome-serverless)
 
 
 ## Computer Science


### PR DESCRIPTION
Add the Serverless Framework (http://serverless.com) to the list of back-end web technologies.