### PR TITLE
Improve PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- Please fill in the **bold** fields and tick all applicable boxes by placing an "x" inside "[ ]". -->
 
-**URL to your list here.**
+**URL to the list here.**
 
 **Explain what this list is all about and why it should be included here.**
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,8 +1,8 @@
-<!-- Please fill in the **bold** fields and tick all applicable boxes in the "Preview" tab. -->
+<!-- Please fill in the **bold** fields and tick all applicable boxes by placing an "x" inside "[ ]". -->
 
 **URL to your list here.**
 
-**Explain what your list is about and why it is awesome enough to be included here.**
+**Explain what this list is all about and why it should be included here.**
 
 - [ ] I have read and understood the [contribution guidelines](https://github.com/sindresorhus/awesome/blob/master/contributing.md) and the [instructions for creating a list](https://github.com/sindresorhus/awesome/blob/master/create-list.md).
 - [ ] This pull request has a descriptive title.


### PR DESCRIPTION
Some small tweaks to the PR template.

1. The "preview" tab has a read-only representation of the Markdown, so it cannot be used to fill in the ticks. Instead, I put basic info how to do it in MD formatting.
2. In #675, there was a complaint the wording of the other thing was silly, so this (hopefully) fixes that.

Feel free to make other changes.