### PR TITLE
Update Awesome Hyperterm to Awesome Hyper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -303,7 +303,7 @@ Check out my [blog](https://blog.sindresorhus.com) and follow me on [Twitter](ht
 - [Git Add-ons](https://github.com/stevemao/awesome-git-addons)
 - [SSH](https://github.com/moul/awesome-ssh)
 - [FOSS for Developers](https://github.com/httpsGithubParty/FOSS-for-Dev)
-- [HyperTerm](https://github.com/bnb/awesome-hyperterm)
+- [Hyper](https://github.com/bnb/awesome-hyper)
 
 
 ## Entertainment


### PR DESCRIPTION
Hyperterm's name is changing to Hyper today - as such, the Awesome repo's name has changed. The commit changes the linking text and the URL to the new one.

I was actually just about to ask you what I should do to resolve what I thought was going to be all the broken backlinks to the old repo - but I just tired it, and the old URL redirected! WOW!

Thanks!