### PR TITLE
Add Java 8

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@ Check out my [blog](https://blog.sindresorhus.com) and follow me on [Twitter](ht
 - [Dart](https://github.com/yissachar/awesome-dart)
 - [Java](https://github.com/akullpp/awesome-java)
 	- [RxJava](https://github.com/eleventigers/awesome-rxjava)
+	- [Java 8](https://github.com/tedyoung/awesome-java8)
 - [Kotlin](https://github.com/KotlinBy/awesome-kotlin)
 - [OCaml](https://github.com/rizo/awesome-ocaml)
 - [ColdFusion](https://github.com/seancoyne/awesome-coldfusion)


### PR DESCRIPTION
Previous attempt: https://github.com/sindresorhus/awesome/pull/472

---

https://github.com/tedyoung/awesome-java8

Highly curated (not everything is awesome) list of libraries, frameworks, etc., for Java 8+ (not 15 year old libraries, the awesome-java repo has those).
- [X] I have read and understood the [contribution guidelines](https://github.com/sindresorhus/awesome/blob/master/contributing.md) and the [instructions for creating a list](https://github.com/sindresorhus/awesome/blob/master/create-list.md).
- [X] This pull request has a descriptive title. _(For example: `Add Node.js`)_
- The list I added
  - [X] **has been around for at least 20 days,**
  - [X] is a non-generated Markdown file in a GitHub repo,
  - [X] is not a duplicate,
  - [X] only has awesome items with descriptions _(Awesome lists are curations of the best, not of everything)_,
  - [X] contains the [awesome badge](https://github.com/sindresorhus/awesome/blob/master/awesome.md#awesome-badge) on the right side of the list heading,
  - [X] has a Table of Contents section named `Contents` as the first section,
  - [X] has an [appropriate license](https://github.com/sindresorhus/awesome/blob/master/awesome.md#choose-an-appropriate-license) _(Meaning something like CC0, NOT a code licence like MIT, BSD, Apache, etc)_,
  - [X] has [contribution guidelines](https://github.com/sindresorhus/awesome/blob/master/awesome.md#include-contribution-guidelines),
  - [X] has been checked for inconsistent formatting, spelling, and grammar _(This includes starting each link description with an uppercase character and ending it with a period `.`, and consistent naming)_,
  - [X] has been added at the bottom of the appropriate category.

Java 8-specific awesomeness. Highly curated, over 100 stars.
