### PR TITLE
Adding Google Dart Flutter.io to Front-End

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -208,6 +208,7 @@
 - [WebGL](https://github.com/sjfricke/awesome-webgl) - JavaScript API for rendering 3D graphics.
 - [Preact](https://github.com/ooade/awesome-preact) - App framework.
 - [Progressive Enhancement](https://github.com/jbmoelker/progressive-enhancement-resources)
+- [Flutter](https://github.com/Solido/awesome-flutter)
 
 
 ## Back-End Development


### PR DESCRIPTION
*Sorry I've asked for a pull to fast, please ignore it until some more days*

Flutter is the Google mobile app SDK for building high-performance, high-fidelity, apps for iOS and Android, from a single codebase. http://flutter.io. It also powers the new coming google os Fuchsia.

Awesome Flutter is the current official list of resources for Flutter developers.


<!-- Congrats on creating an Awesome list! 🎉 -->

**https://github.com/Solido/awesome-flutter**

**Awesome Flutter is currently the sole collection to list Flutter related resources and has a goal of helping developer to quickly find components and best practice to get started. 
It is supported by the Google Flutter team.**


# By submitting this pull request I confirm I've read and complied with the below requirements.

**Please read it multiple times. I spent a lot of time on these guidelines and most people miss a lot.**

- I have read and understood the [contribution guidelines](https://github.com/sindresorhus/awesome/blob/master/contributing.md) and the [instructions for creating a list](https://github.com/sindresorhus/awesome/blob/master/create-list.md).
- This pull request has a descriptive title.<br>For example, `Add Name of List`, not `Update readme.md` or `Add awesome list`.
- The entry in the Awesome list should:
	- Include a short description about the project/theme of the list. **It should not describe the list itself.**<br>Example: `- [Fish](…) - User-friendly shell.`, not `- [Fish](…) - Resources for Fish.`.
	- Be added at the bottom of the appropriate category.
- The list I'm submitting complies with these requirements:
	- **X** **Has been around for at least 30 days.**<br>That means 30 days from either the first real commit or when it was open-sourced. Whatever is most recent.
	- It's the result of hard work and the best I could possibly produce.
	- Non-generated Markdown file in a GitHub repo.
	- **Includes a succinct description of the project/theme at the top of the readme.** [(Example)](https://github.com/willempienaar/awesome-quantified-self)
	- The repo should have `awesome-list` & `awesome` as [GitHub topics](https://help.github.com/articles/about-topics). I encourage you to add more relevant topics.
	- Not a duplicate.
	- Only has awesome items. Awesome lists are curations of the best, not everything.
	- Includes a project logo/illustration whenever possible.
		- Placed at the top-right of the readme. [(Example)](https://github.com/sindresorhus/awesome-electron)
		- The image should link to the project website or any relevant website.
		- The image should be high-DPI. Set it to maximum half the width of the original image.
	- Entries have a description, unless the title is descriptive enough by itself. It rarely is though.
	- Has the [Awesome badge](https://github.com/sindresorhus/awesome/blob/master/awesome.md#awesome-badge) on the right side of the list heading,
	- Has a Table of Contents section.
		- Should be named `Contents`, not `Table of Contents`.
		- Should be the first section in the list.
	- Has an [appropriate license](https://github.com/sindresorhus/awesome/blob/master/awesome.md#choose-an-appropriate-license).
		- That means something like CC0, **not a code licence like MIT, BSD, Apache, etc.**
		- If you use a license badge, it should be SVG, not PNG.
	- Has [contribution guidelines](https://github.com/sindresorhus/awesome/blob/master/awesome.md#include-contribution-guidelines).
		- The file should be named `contributing.md`. Casing is up to you.
	- Has consistent formatting and proper spelling/grammar.
		- Each link description starts with an uppercase character and ends with a period.<br>Example: `- [AVA](…) - JavaScript test runner.`
		- Drop all the `A` / `An` prefixes in the descriptions.
		- Consistent and correct naming. For example, `Node.js`, not `NodeJS` or `node.js`.
	- Doesn't include a Travis badge.<br>You can still use Travis for list linting, but the badge has no value in the readme.
- Go to the top and read it again.
