### PR TITLE
Shorten the Laravel Education link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -244,7 +244,7 @@
 - [Symfony](https://github.com/sitepoint-editors/awesome-symfony)
 	- [Education](https://github.com/pehapkari/awesome-symfony-education)
 - [Laravel](https://github.com/chiraggude/awesome-laravel) - PHP framework.
-	- [Education](https://github.com/fukuball/Awesome-Laravel-Education/blob/master/langs/en_US.md)
+	- [Education](https://github.com/fukuball/Awesome-Laravel-Education)
 - [Rails](https://github.com/ekremkaraca/awesome-rails) - Web app framework for Ruby.
 	- [Gems](https://github.com/hothero/awesome-rails-gem) - Packages.
 - [Phalcon](https://github.com/phalcon/awesome-phalcon)


### PR DESCRIPTION
shortens:
`https://github.com/fukuball/Awesome-Laravel-Education/blob/master/langs/en_US.md`
to:
`https://github.com/fukuball/Awesome-Laravel-Education`
for consistency

Cannot shorten `https://github.com/shlomi-noach/awesome-mysql/blob/gh-pages/index.md`, made shlomi-noach/awesome-mysql#63