### PR TITLE
Update title casing website in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -18,7 +18,7 @@ Please ensure your pull request adheres to the following guidelines:
 - Search previous suggestions before making a new one, as yours may be a duplicate.
 - Make sure the list is useful before submitting. That implies it has enough content and every item has a good succinct description.
 - Make an individual pull request for each suggestion.
-- Use [title-casing](http://titlecapitalization.com) (AP style).
+- Use [title-casing](http://titlecase.com) (AP style).
 - Use the following format: `[List Name](link)`
 - Link additions should be added to the bottom of the relevant category.
 - New categories or improvements to the existing categorization are welcome.


### PR DESCRIPTION
Old (dead): http://titlecapitalization.com

New (up): http://titlecase.com