### PR TITLE
Update Awesome Game Boy Development list link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -349,7 +349,7 @@
 - [Chess](https://github.com/hkirat/awesome-chess#readme)
 - [LÖVE](https://github.com/love2d-community/awesome-love2d#readme) - Game engine.
 - [PICO-8](https://github.com/felipebueno/awesome-PICO-8#readme) - Fantasy console.
-- [Game Boy Development](https://github.com/avivace/awesome-gbdev#readme)
+- [Game Boy Development](https://github.com/gbdev/awesome-gbdev#readme)
 - [Construct 2](https://github.com/armaldio/awesome-construct#readme) - Game engine.
 - [Gideros](https://github.com/stetso/awesome-gideros#readme) - Game engine.
 


### PR DESCRIPTION
We moved the repository from my personal account (`avivace/awesome-gbdev`) to a more neutral organisation (`gbdev/awesome-gbdev`).
