### PR TITLE
Add ESP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@
 - [Adafruit IO](https://github.com/adafruit/awesome-adafruitio#readme) - Visualize and store data from any device.
 - [Cloudflare](https://github.com/irazasyed/awesome-cloudflare#readme) - CDN, DNS, DDoS protection, and security for your site.
 - [Actions on Google](https://github.com/ravirupareliya/awesome-actions-on-google#readme) - Developer platform for Google Assistant.
-- [ESP](https://github.com/agucova/awesome-esp#readme) - Two low-cost microcontrollers with WiFi, having broad IoT applications.
+- [ESP](https://github.com/agucova/awesome-esp#readme) - Low-cost microcontrollers with WiFi and broad IoT applications.
 
 
 ## Programming Languages

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@
 - [Fuse](https://github.com/fuse-compound/awesome-fuse#readme) - Mobile development tools.
 - [Heroku](https://github.com/ianstormtaylor/awesome-heroku#readme) - Cloud platform as a service.
 - [Raspberry Pi](https://github.com/thibmaek/awesome-raspberry-pi#readme) - Credit card-sized computer aimed at teaching kids programming, but capable of a lot more.
+- [ESP](https://github.com/agucova/awesome-esp#readme) - Two low-cost microcontrollers with WiFi, having broad applications in the Internet of Things.
 - [Qt](https://github.com/JesseTG/awesome-qt#readme) - Cross-platform GUI app framework.
 - [WebExtensions](https://github.com/fregante/Awesome-WebExtensions#readme) - Cross-browser extension system.
 - [RubyMotion](https://github.com/motion-open-source/awesome-rubymotion#readme) - Write cross-platform native apps for iOS, Android, macOS, tvOS, and watchOS in Ruby.

--- a/readme.md
+++ b/readme.md
@@ -148,7 +148,6 @@
 - [Actions on Google](https://github.com/ravirupareliya/awesome-actions-on-google#readme) - Developer platform for Google Assistant.
 - [ESP](https://github.com/agucova/awesome-esp#readme) - Low-cost microcontrollers with WiFi and broad IoT applications.
 
-
 ## Programming Languages
 
 - [JavaScript](https://github.com/sorrycc/awesome-javascript#readme)

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,6 @@
 - [Fuse](https://github.com/fuse-compound/awesome-fuse#readme) - Mobile development tools.
 - [Heroku](https://github.com/ianstormtaylor/awesome-heroku#readme) - Cloud platform as a service.
 - [Raspberry Pi](https://github.com/thibmaek/awesome-raspberry-pi#readme) - Credit card-sized computer aimed at teaching kids programming, but capable of a lot more.
-- [ESP](https://github.com/agucova/awesome-esp#readme) - Two low-cost microcontrollers with WiFi, having broad applications in the Internet of Things.
 - [Qt](https://github.com/JesseTG/awesome-qt#readme) - Cross-platform GUI app framework.
 - [WebExtensions](https://github.com/fregante/Awesome-WebExtensions#readme) - Cross-browser extension system.
 - [RubyMotion](https://github.com/motion-open-source/awesome-rubymotion#readme) - Write cross-platform native apps for iOS, Android, macOS, tvOS, and watchOS in Ruby.
@@ -147,6 +146,8 @@
 - [Adafruit IO](https://github.com/adafruit/awesome-adafruitio#readme) - Visualize and store data from any device.
 - [Cloudflare](https://github.com/irazasyed/awesome-cloudflare#readme) - CDN, DNS, DDoS protection, and security for your site.
 - [Actions on Google](https://github.com/ravirupareliya/awesome-actions-on-google#readme) - Developer platform for Google Assistant.
+- [ESP](https://github.com/agucova/awesome-esp#readme) - Two low-cost microcontrollers with WiFi, having broad IoT applications.
+
 
 ## Programming Languages
 


### PR DESCRIPTION
The ESP8266 and ESP32 have become highly popular, and the go-to devices for a good chunk of DIY IoT projects, largely replacing the Raspberry Pi in small embedded uses.

**https://github.com/agucova/awesome-esp#readme**

The list includes cool projects, useful libraries, tools and firmware for both microcontrollers. Note that I disabled two linter rules, both, I believe, false positives. (I'll raise an issue in awesome-lint).

**By submitting this pull request I confirm I've read and complied with the [requirements](https://github.com/sindresorhus/awesome/blob/master/pull_request_template.md) 🖖**

Pull requests reviewed: #1688 and #1687.