### PR TITLE
Update pull request template link to use `main` branch

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -76,7 +76,7 @@
 	- Should only have one level of [nested lists](https://commonmark.org/help/tutorial/10-nestedLists.html), preferably none.
 - Has an appropriate license.
 	- **We strongly recommend the [CC0 license](https://creativecommons.org/publicdomain/zero/1.0/), but any [Creative Commons license](https://creativecommons.org/choose/) will work.**
-		- Tip: You can quickly add it to your repo by going to this URL: `https://github.com/<user>/<repo>/community/license/new?branch=master&template=cc0-1.0` (replace `<user>` and `<repo>` accordingly).
+		- Tip: You can quickly add it to your repo by going to this URL: `https://github.com/<user>/<repo>/community/license/new?branch=main&template=cc0-1.0` (replace `<user>` and `<repo>` accordingly).
 	- A code license like MIT, BSD, Apache, GPL, etc, is not acceptable. Neither are WTFPL and [Unlicense](https://unlicense.org).
 	- Place a file named `license` or `LICENSE` in the repo root with the license text.
 	- **Do not** add the license name or text to the readme. GitHub already shows the license name at the top of the repo.


### PR DESCRIPTION
Now that we want users to use the `main` branch instead of `master` branch, this PR updates the LICENCE setup link accordingly.