### PR TITLE
Fix link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -541,7 +541,7 @@
 - [Clean Tech](https://github.com/nglgzz/awesome-clean-tech#readme) - Fighting climate change with technology.
 - [Wardley Maps](https://github.com/wardley-maps-community/awesome-wardley-maps#readme) - Provides high situational awareness to help improve strategic planning and decision making.
 - [Social Enterprise](https://github.com/RayBB/awesome-social-enterprise#readme) - Building an organization primarily focused on social impact that is at least partially self-funded.
-- [Engineering Team Management](https://github.com/kdeldycke/awesome-management#readme) - How to transition from software development to engineering management.
+- [Engineering Team Management](https://github.com/kdeldycke/awesome-engineering-team-management#readme) - How to transition from software development to engineering management.
 
 ## Work
 


### PR DESCRIPTION
This PR fix canonical URL of the `Awesome Engineering Team Management` repository as suggested by @sindresorhus at https://github.com/sindresorhus/awesome/pull/1887#issuecomment-718792635 .

This is a follow up of https://github.com/sindresorhus/awesome/pull/1887 .