### PR TITLE
Add Projen

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -332,6 +332,7 @@
 - [FastAPI](https://github.com/mjhea0/awesome-fastapi#readme) - Python web app framework.
 - [CDK](https://github.com/kolomied/awesome-cdk#readme) - Open-source software development framework for defining cloud infrastructure in code.
 - [IAM](https://github.com/kdeldycke/awesome-iam#readme) - User accounts, authentication and authorization.
+- [Projen](https://github.com/p6m7g8/awesome-projen#readme) - Open-source; define and maintain complex project configuration through code.
 
 ## Computer Science
 


### PR DESCRIPTION
https://github.com/p6m7g8/awesome-projen

Reviewed: #1794, #1823, #1980

This list provides the projen community a central place for reference patterns and use.

`projen` is actually pretty important, it is used by several MAJOR opensource projects like:
- CDK8s now in the Cloud Native Computing Foundation (CNCF)
- CDKtf HashiCorp's terraform CDK
- Armkit Community Driven Azure CDK
- Constructs the AWS projects underpinning AWS CDK
- Construct Cataloge the Open Source index of CDK Constructs

There are already over 1,000 GitHub repos using projen and it was featured at CDK Day 2020.
It will be featured again at CDK Day in 2021. This is a global community driven event attracting
thousands.

As projen itself is an NPM module it needs maintenance so this already includes
dependabot, mergify, codecov, codeql, synk to keep it up to date without intervention.

This list, based on p6-projen-project-awesome-list, is self updating too.

All PRs also run npx awesome-lint automatically before allowing merge.

I have gone to great lenghts to automate in code the requests in the pull_request_template.

I am open to anything I missed.
