### PR TITLE
Update link to Grakn

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -484,7 +484,7 @@
 - [NoSQL Guides](https://github.com/erictleung/awesome-nosql-guides#readme) - Help on using non-relational, distributed, open-source, and horizontally scalable databases.
 - [Contexture](https://github.com/chrislatorres/awesome-contexture#readme) - Abstracts queries/filters and results/aggregations from different backing data stores like ElasticSearch and MongoDB.
 - [Database Tools](https://github.com/mgramin/awesome-db-tools#readme) - Everything that makes working with databases easier.
-- [Grakn](https://github.com/graknlabs/awesome#readme) - Logical database to organize large and complex networks of data as one body of knowledge.
+- [TypeDB](https://github.com/vaticle/typedb-awesome#readme) - Logical database to organize large and complex networks of data as one body of knowledge.
 
 ## Media
 


### PR DESCRIPTION
As we've going through the process of rebranding organisation (GraknLabs becomes Vaticle and Grakn becomes TypeDB), it makes sense to update the reference in Awesome Lists