### PR TITLE
Use absolute links in pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -15,7 +15,7 @@
 - **Don't waste my time.** Do a good job, adhere to all the guidelines, and be responsive.
 - **You have to review at least 2 other [open pull requests](https://github.com/sindresorhus/awesome/pulls?q=is%3Apr+is%3Aopen).**
 	Try to prioritize unreviewed PRs, but you can also add more comments to reviewed PRs. Go through the below list when reviewing. This requirement is meant to help make the Awesome project self-sustaining. Comment here which PRs you reviewed. You're expected to put a good effort into this and to be thorough. Look at previous PR reviews for inspiration. **Just commenting “looks good” or simply marking the pull request as approved does not count!** You have to actually point out mistakes or improvement suggestions.
-- You have read and understood the [instructions for creating a list](create-list.md).
+- You have read and understood the [instructions for creating a list](https://github.com/sindresorhus/awesome/blob/main/create-list.md).
 - This pull request has a title in the format `Add Name of List`.
 	- ✅ `Add Swift`
 	- ✅ `Add Software Architecture`
@@ -69,7 +69,7 @@
 	- The image should link to the project website or any relevant website.
 	- **The image should be high-DPI.** Set it to maximum half the width of the original image.
 - Entries have a description, unless the title is descriptive enough by itself. It rarely is though.
-- Includes the [Awesome badge](awesome.md#awesome-badge).
+- Includes the [Awesome badge](https://github.com/sindresorhus/awesome/blob/main/awesome.md#awesome-badge).
 	- Should be placed on the right side of the readme heading.
 		- Can be placed centered if the list has a centered graphics header.
 	- Should link back to this list.
@@ -85,7 +85,7 @@
 	- Place a file named `license` or `LICENSE` in the repo root with the license text.
 	- **Do not** add the license name, text, or a `Licence` section to the readme. GitHub already shows the license name and link to the full text at the top of the repo.
 	- To verify that you've read all the guidelines, please comment on your pull request with just the word `unicorn`.
-- Has [contribution guidelines](awesome.md#include-contribution-guidelines).
+- Has [contribution guidelines](https://github.com/sindresorhus/awesome/blob/main/awesome.md#include-contribution-guidelines).
 	- The file should be named `contributing.md`. Casing is up to you.
 	- It can optionally be linked from the readme in a dedicated section titled `Contributing`, positioned at the top or bottom of the main content.
 	- The section should not appear in the Table of Contents.


### PR DESCRIPTION
Currently, the relative links don't work in the pull requests itself.

Also tried using with a slash at the beginning (`[Link](/...)`) but this doesn't work either.