### PR TITLE
Update repo_linter.sh to perform shallow clone instead of full clone

### DIFF
--- a/.github/workflows/repo_linter.sh
+++ b/.github/workflows/repo_linter.sh
@@ -17,6 +17,6 @@ else
 	echo "Cloning $REPO_TO_LINT"
 	mkdir cloned
 	cd cloned
-	git clone "$REPO_TO_LINT" .
+	git clone --depth 1 "$REPO_TO_LINT" .
 	npx awesome-lint
 fi


### PR DESCRIPTION
This will lead to faster clones. Full history isn't required for linting.
