### PR TITLE
Add CI to automate heavy PR load

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,3 +12,5 @@ jobs:
           fetch-depth: 0
       - name: awesome-lint
         run: ./.github/workflows/repo_linter.sh
+      - name: Run awesome-lint on readme.md
+        run: npx awesome-lint readme.md

--- a/.github/workflows/repo_linter.sh
+++ b/.github/workflows/repo_linter.sh
@@ -20,3 +20,6 @@ else
 	git clone "$REPO_TO_LINT" .
 	npx awesome-lint
 fi
+
+# Lint the repository using awesome-lint
+npx awesome-lint

--- a/contributing.md
+++ b/contributing.md
@@ -28,3 +28,18 @@ You'll need a [GitHub account](https://github.com/join)!
 Sometimes, a maintainer of an awesome list will ask you to edit your Pull Request before it is included. This is normally due to spelling errors or because your PR didn't match the awesome-* list guidelines.
 
 [Here](https://github.com/RichardLitt/knowledge/blob/master/github/amending-a-commit-guide.md) is a write up on how to change a Pull Request and the different ways you can do that.
+
+## Running `awesome-lint` before submitting a PR
+
+Before submitting a pull request, please ensure that your changes pass the `awesome-lint` checks. This helps maintain the quality and consistency of the repository.
+
+To run `awesome-lint`, use the following command:
+
+```sh
+npx awesome-lint
+```
+
+## Pull Request Guidelines
+
+- Ensure your pull request adheres to the [list of guidelines](pull_request_template.md).
+- Your pull request must pass the `awesome-lint` checks.

--- a/readme.md
+++ b/readme.md
@@ -900,3 +900,15 @@
 - [Awesome CLI](https://github.com/umutphp/awesome-cli) - A simple command-line tool to dive into Awesome lists.
 - [Awesome Viewer](https://awesome.digitalbunker.dev) - A visualizer for all of the above Awesome lists.
 - [Track Awesome List](https://www.trackawesomelist.com) - View the latest updates of Awesome lists.
+
+## Contribution Guide
+
+We use `awesome-lint` for CI to ensure that all contributions adhere to our guidelines. Please make sure to run `awesome-lint` before submitting a pull request.
+
+To run `awesome-lint`, use the following command:
+
+```sh
+npx awesome-lint
+```
+
+For more details, refer to the [Contribution guide](contributing.md).


### PR DESCRIPTION
Related to #1365

Implement CI to automate heavy PR load using `awesome-lint`.

* **.github/workflows/main.yml**
  - Add a step to run `awesome-lint` on `readme.md` after the checkout step.
* **.github/workflows/repo_linter.sh**
  - Add `npx awesome-lint` command to lint the repository after cloning.
* **readme.md**
  - Mention the usage of `awesome-lint` for CI in the introduction.
  - Add a section about `awesome-lint` in the "Contribution guide".
* **contributing.md**
  - Add instructions for running `awesome-lint` before submitting a PR.
  - Mention the requirement to pass `awesome-lint` in the PR guidelines.

