### PR TITLE
Add SDR

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -671,6 +671,7 @@
 - [Open Hardware](https://github.com/delftopenhardware/awesome-open-hardware#readme) - Open-source hardware projects.
 - [ADS-B](https://github.com/rickstaa/awesome-adsb#readme) - Technology broadcasting aircraft's identity, position, and data periodically.
 - [Flying FPV](https://github.com/Matthias84/awesome-flying-fpv#readme) - Open hardware and software related to drones / UAVs.
+- [Software Defined Radio](https://github.com/vkvbit/awesome-sdr#readme) - SDR related softwares and resources.
 
 ## Business
 


### PR DESCRIPTION
A list of awesome Software Defined Radio (SDR) software, drivers, frameworks, libraries, tools.

[Awseome SDR](https://github.com/vkvbit/awesome-sdr#readme)

Why this list should be included?
This list specifically for LimeSDR and HackRF, both of the hardwares are open-sources. Turns out it can be used to build practically any communication infrastructure using it. There are very limited resources in this field for beginners. It can be a starting point for them.

By submitting this pull request I confirm I've read and complied with the below requirements 🖖