### PR TITLE
docs: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: awesome-lint


### PR DESCRIPTION
This PR updates an outdated GitHub Action version.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/main.yml`
