### PR TITLE
Fix: Remove duplicate paragraph tag in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,11 @@
 	<br>
 	<hr>
 	<p>
-		<p>
-			<sup>
-				<a href="https://github.com/sponsors/sindresorhus">My open source work is supported by the community</a>
-			</sup>
-		</p>
+		<sup>
+			<a href="https://github.com/sponsors/sindresorhus">My open source work is supported by the community</a>
+		</sup>
+	</p>
+	<p>
 		<sup>Special thanks to:</sup>
 		<br>
 		<br>


### PR DESCRIPTION
### What was fixed
- Removed duplicate `<p>` tag on line 17 of readme.md
- This was causing invalid HTML structure

### Why this matters
- Improves HTML validity
- Ensures proper rendering across all browsers
- Follows web standards best practices

### Changes made
- Changed nested `<p><p>` to single `<p>` tag
- No functional changes, only code quality improvement
