### PR TITLE
Add Code Docs to Miscellaneous

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -888,6 +888,7 @@
 - [OpenStreetMap](https://github.com/osmlab/awesome-openstreetmap#readme) - An open data mapping project utilized by many apps and devices.
 - [Computational Biology](https://github.com/inoue0426/awesome-computational-biology#readme) - Computational approaches applied to problems in biology.
 - [Read the Docs](https://github.com/readthedocs-examples/awesome-read-the-docs#readme) - Example documentation projects to inspire and help bootstrap new documentation projects.
+- [Code Docs](https://github.com/johnxie/awesome-code-docs#readme) - Deep-dive tutorials for understanding open-source project architectures and internals.
 - [Quarto](https://github.com/mcanouil/awesome-quarto#readme) - Scientific and technical open-source publishing system built on Pandoc.
 - [Biological Image Analysis](https://github.com/hallvaaw/awesome-biological-image-analysis#readme) - Interpreting biological phenomena using images.
 - [ChatGPT](https://github.com/sindresorhus/awesome-chatgpt#readme) - Artificial intelligence chatbot developed by OpenAI.


### PR DESCRIPTION
## Summary
- adds Code Docs to the Miscellaneous section

## Why
Code Docs is an awesome-style curated list of deep technical tutorials focused on open-source project architecture and internals, complementing existing documentation-oriented entries.