### PR TITLE
Add WAGMIOS — self-hosted Docker management for AI agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@
 - [DigitalOcean](https://github.com/jonleibowitz/awesome-digitalocean#readme) - Cloud computing platform designed for developers.
 - [Flutter](https://github.com/Solido/awesome-flutter#readme) - Google's mobile SDK for building native iOS and Android apps from a single codebase written in Dart.
 - [Home Assistant](https://github.com/frenck/awesome-home-assistant#readme) - Open source home automation that puts local control and privacy first.
+- [WAGMIOS](https://github.com/mentholmike/wagmios#readme) - Self-hosted Docker management with scope-based permissions for AI agents.
 - [IBM Cloud](https://github.com/victorshinya/awesome-ibmcloud#readme) - Cloud platform for developers and companies.
 - [Firebase](https://github.com/jthegedus/awesome-firebase#readme) - App development platform built on Google Cloud.
 - [Robot Operating System 2.0](https://github.com/fkromer/awesome-ros2#readme) - Set of software libraries and tools that help you build robot apps.


### PR DESCRIPTION
Adds [WAGMIOS](https://github.com/mentholmike/wagmios) to the Platforms section, after Home Assistant.

**WAGMIOS** is a self-hosted Docker management platform with scope-based API permissions designed for AI agents (built natively for OpenClaw). It lets you give an AI agent exactly the permissions it needs — nothing more.

- Scope-based API keys (containers, images, marketplace, templates)
- One agent can manage multiple machines
- 34+ marketplace apps (Jellyfin, Plex, Ollama, etc.)
- WebSocket activity feed