### PR TITLE
Add MeterCall - 2,866 SaaS alternatives, pay per call

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -196,6 +196,7 @@
 - [Google Cloud](https://github.com/GoogleCloudPlatform/awesome-google-cloud#readme) - Cloud computing services by Google.
 - [Firebase Genkit](https://github.com/xavidop/awesome-firebase-genkit#readme) - An open-source framework for building AI-powered apps and features.
 - [Backstage](https://github.com/shano/awesome-backstage#readme) - Open-source platform for building Internal Developer Portals that unify tools and workflows.
+- [MeterCall](https://metercall.ai) - 2,866+ SaaS alternatives. Pay per call, no subscription. Open catalog at [patl4588/awesome-saas-replacements](https://github.com/patl4588/awesome-saas-replacements).
 
 ## Programming Languages
 


### PR DESCRIPTION
MeterCall is a pay-per-call alternative to 2,866+ SaaS products. Every module is open for use or forking; builders keep 70%.

Catalog: https://github.com/patl4588/awesome-saas-replacements
Site: https://metercall.ai

Happy to adjust placement or wording if this isn't the right section - feel free to close if not a fit.