### PR TITLE
Add Deception

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -659,6 +659,7 @@
 - [Annual Security Reports](https://github.com/jacobdjwilson/awesome-annual-security-reports#readme) - Exploring cybersecurity trends, insights, and challenges.
 - [CI/CD Attacks](https://github.com/TupleType/awesome-cicd-attacks#readme) - Offensive research of systems and processes related to developing and deploying code.
 - [OpenID Connect](https://github.com/cerberauth/awesome-openid-connect#readme) - Identity standard and authentication protocol built on OAuth 2.0 for user identity assertion.
+- [Deception](https://github.com/tracebit-com/awesome-deception#readme) - Through deception, misleading attackers with honeypots, honeytokens, and decoys to detect, study, and disrupt intrusions.
 
 ## Content Management Systems
 


### PR DESCRIPTION
**https://github.com/tracebit-com/awesome-deception**

A curated list of articles, papers, talks, frameworks, guides, and conferences for cyber deception — defensive techniques that mislead attackers using honeypots, honeytokens, decoys, and canaries.

The repo:

- Has been around since January 2026 (well past the 30-day minimum).
- Is licensed CC0 1.0 and the license is detected by GitHub.
- Has `awesome` and `awesome-list` as topics.
- Uses `main` as the default branch.
- Includes a `contributing.md` and a `Footnotes` section.
- Passes `awesome-lint` cleanly.
- Is human-curated, not AI-generated.

The closest existing entry is `Honeypots` ([awesome-honeypots](https://github.com/paralax/awesome-honeypots)), which is scoped to open source honeypot tooling. `awesome-deception` covers the broader discipline — research, articles, talks, frameworks (MITRE Engage, D3FEND), and operational guidance — and explicitly directs honeypot tooling submissions to that list to keep the two complementary rather than overlapping.