### PR TITLE
Clarify maintainer response expectations

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -37,6 +37,11 @@ Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
+Project maintainers are also expected to help keep the project healthy by
+reviewing issues and pull requests within a reasonable time. If they cannot
+keep up with updates, they should add more maintainers or hand the project
+over to someone who can.
+
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -37,11 +37,6 @@ Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Project maintainers are also expected to help keep the project healthy by
-reviewing issues and pull requests within a reasonable time. If they cannot
-keep up with updates, they should add more maintainers or hand the project
-over to someone who can.
-
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or

--- a/create-list.md
+++ b/create-list.md
@@ -5,6 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
-- Be prepared to spend time maintaining your list. Try to review issues and pull requests within a reasonable time, and if you cannot keep up with updates, ask for help from additional maintainers.
+- Be prepared to spend time maintaining your list. People rely on awesome lists to discover quality resources, so try to review issues and pull requests within a reasonable time. If you cannot keep up with updates, ask for help from additional maintainers.
 
 Thanks for being awesome! 😎

--- a/create-list.md
+++ b/create-list.md
@@ -5,6 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
-- Be prepared to spend time maintaining your list. People rely on awesome lists to discover quality resources, so try to review issues and pull requests within a reasonable time. If you cannot keep up with updates, ask for help from additional maintainers.
+- Be prepared to spend time maintaining your list. People rely on awesome lists to discover quality resources, so try to review issues and pull requests within a reasonable time. If you cannot keep up with updates, add more maintainers or hand the list over to someone who can.
 
 Thanks for being awesome! 😎

--- a/create-list.md
+++ b/create-list.md
@@ -5,6 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
-- Be prepared to spend time maintaining your list. People rely on awesome lists to discover quality resources, so try to review issues and pull requests within a reasonable time. If you cannot keep up with updates, add more maintainers or hand the list over to someone who can.
+- Be prepared to spend time maintaining your list. Try to review issues and pull requests within a reasonable time, and if you cannot keep up with updates, ask for help from additional maintainers.
 
 Thanks for being awesome! 😎

--- a/create-list.md
+++ b/create-list.md
@@ -5,6 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
-- Be prepared to spend time maintaining your list. Try to review issues and pull requests within a reasonable time, and if you expect to be unavailable or cannot keep up with updates, ask for help from additional maintainers so the list does not stall.
+- Be prepared to spend time maintaining your list. Review issues and pull requests in a timely manner, and if you expect to be unavailable or cannot keep up with updates, ask for help from additional maintainers so the list does not stall.
 
 Thanks for being awesome! 😎

--- a/create-list.md
+++ b/create-list.md
@@ -5,6 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
-- Be prepared to spend time maintaining your list. Try to review issues and pull requests within a reasonable time, and if you cannot keep up with updates, ask for help from additional maintainers.
+- Be prepared to spend time maintaining your list. Try to review issues and pull requests within a reasonable time, and if you expect to be unavailable or cannot keep up with updates, ask for help from additional maintainers so the list does not stall.
 
 Thanks for being awesome! 😎

--- a/create-list.md
+++ b/create-list.md
@@ -5,5 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
+- Be prepared to spend time maintaining your list. If you cannot keep up with updates or pull requests, ask for help from additional maintainers.
 
 Thanks for being awesome! 😎

--- a/create-list.md
+++ b/create-list.md
@@ -5,6 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
-- Be prepared to spend time maintaining your list. If you cannot keep up with updates or pull requests, ask for help from additional maintainers.
+- Be prepared to spend time maintaining your list. Try to review issues and pull requests within a reasonable time, and if you cannot keep up with updates, ask for help from additional maintainers.
 
 Thanks for being awesome! 😎


### PR DESCRIPTION
## Summary
- add guidance in `create-list.md` that prospective Awesome list maintainers should review issues and pull requests in a timely manner
- encourage maintainers who expect to be unavailable or cannot keep up with updates to ask for additional maintainers so the list does not stall
- address the concern raised in #748 in the list creation guidance instead of changing the Contributor Covenant text

## Why
Issue #748 asks for clearer expectations around maintainer responsiveness on Awesome lists. Putting this guidance in `create-list.md` warns prospective maintainers about the time commitment up front and encourages them to bring in help if they cannot keep up.

Closes #748.
