### PR TITLE
Clarify list maintainer responsiveness expectations

### DIFF
--- a/create-list.md
+++ b/create-list.md
@@ -5,5 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
+- Be prepared to spend time maintaining your list. Try to review issues and pull requests within a reasonable time, and if you cannot keep up with updates, ask for help from additional maintainers.
 
 Thanks for being awesome! 😎


### PR DESCRIPTION
## Summary
- add a short note to the list creation guide that maintainers should review issues and pull requests within a reasonable time
- suggest asking additional maintainers for help when updates start to pile up

## Why
- addresses #748 by setting expectations for prospective list maintainers before they submit a list
- keeps the change focused on maintainer guidance instead of expanding the contributor code of conduct beyond community behavior
