### PR TITLE
Clarify maintainer responsiveness expectations

### DIFF
--- a/create-list.md
+++ b/create-list.md
@@ -5,5 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
+- Be prepared to spend time maintaining your list. Try to review issues and pull requests within a reasonable time, and if you cannot keep up with updates, ask for help from additional maintainers.
 
 Thanks for being awesome! 😎


### PR DESCRIPTION
## Summary
- add a short note in `create-list.md` that prospective Awesome list maintainers should review issues and pull requests within a reasonable time
- recommend asking additional maintainers for help when a list owner cannot keep up with updates
- address the concern raised in #748 without expanding the Code of Conduct beyond behavioral expectations

## Why
Issue #748 asks for clearer guidance that maintaining an Awesome list includes a responsibility to stay responsive, or to bring in help when that is not possible. Adding this expectation to the list creation guidance sets that expectation for new maintainers in the most relevant place.

Closes #748.
