### PR TITLE
Clarify maintainer responsiveness expectations for new lists

### DIFF
--- a/create-list.md
+++ b/create-list.md
@@ -5,5 +5,6 @@
 - You might find [this Yeoman generator](https://github.com/dar5hak/generator-awesome-list) useful.
 - **Wait at least 30 days after creating a list before submitting it, to give it a chance to mature.**
 - **Make sure you read the [list guidelines](pull_request_template.md) again before submitting a pull request for your list to be added here.**
+- Be prepared to spend time maintaining your list. Review issues and pull requests in a timely manner, and if you expect to be unavailable or cannot keep up with updates, ask for help from additional maintainers so the list does not stall.
 
 Thanks for being awesome! 😎


### PR DESCRIPTION
## Summary
- tell prospective list maintainers that awesome lists need ongoing attention after they are accepted
- ask maintainers to review issues and pull requests in a timely manner or add extra maintainers when they cannot keep up
- address the concern raised in #748 without expanding the code of conduct beyond contributor behavior

## Why
The discussion in #748 asks for clearer guidance about the responsibility that comes with maintaining an awesome list. Adding that expectation to the list creation guide is a small, targeted way to set expectations for new maintainers while acknowledging that shared maintenance is the fallback when availability changes.