### PR TITLE
Add mcp-safeguard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -632,6 +632,7 @@
 - [Annual Security Reports](https://github.com/jacobdjwilson/awesome-annual-security-reports#readme) - Exploring cybersecurity trends, insights, and challenges.
 - [CI/CD Attacks](https://github.com/TupleType/awesome-cicd-attacks#readme) - Offensive research of systems and processes related to developing and deploying code.
 - [OpenID Connect](https://github.com/cerberauth/awesome-openid-connect#readme) - Identity standard and authentication protocol built on OAuth 2.0 for user identity assertion.
+- [mcp-safeguard](https://github.com/SyedAnas01/mcp-safeguard) - Security scanner for MCP servers — detect prompt injection, credential leaks, and tool poisoning in AI agent tooling.
 
 ## Content Management Systems
 


### PR DESCRIPTION
Adds mcp-safeguard to Security section. It's a security scanner specifically for MCP (Model Context Protocol) servers — the open standard connecting AI agents to real-world tools. Detects prompt injection, credential leaks, exposed endpoints, and tool poisoning. `pip install mcp-safeguard` · https://github.com/SyedAnas01/mcp-safeguard