### PR TITLE
Add Python Docs link to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,7 +199,7 @@
 	- [Data Science](https://github.com/krzjoa/awesome-python-data-science#readme) - Data analysis and machine learning.
 	- [Typing](https://github.com/typeddjango/awesome-python-typing#readme) - Optional static typing for Python.
 	- [MicroPython](https://github.com/mcauser/awesome-micropython#readme) - A lean and efficient implementation of Python 3 for microcontrollers.
-    - [Python Docs](docs.python.org) - The official documentation for the Python programming language.
+    - [Python on GitHub](https://github.com/python) - Official Python repositories.
 - [Rust](https://github.com/rust-unofficial/awesome-rust#readme)
 	- [Pest](https://github.com/pest-parser/awesome-pest#readme) - Parser generator.
 - [Haskell](https://github.com/krispo/awesome-haskell#readme)

--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,7 @@
 	- [Data Science](https://github.com/krzjoa/awesome-python-data-science#readme) - Data analysis and machine learning.
 	- [Typing](https://github.com/typeddjango/awesome-python-typing#readme) - Optional static typing for Python.
 	- [MicroPython](https://github.com/mcauser/awesome-micropython#readme) - A lean and efficient implementation of Python 3 for microcontrollers.
+    - [Python Docs](docs.python.org) - The official documentation for the Python programming language.
 - [Rust](https://github.com/rust-unofficial/awesome-rust#readme)
 	- [Pest](https://github.com/pest-parser/awesome-pest#readme) - Parser generator.
 - [Haskell](https://github.com/krispo/awesome-haskell#readme)


### PR DESCRIPTION
Added the link to the official Python documentation in the Programming Languages section. It's an essential resource for developers.