### PR TITLE
Add HTML to Markdown Converter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -352,6 +352,7 @@
 - [Frontend GIS](https://github.com/joewdavies/awesome-frontend-gis#readme) - Geographic Information Systems (GIS) for web browsers.
 - [WebGPU](https://github.com/mikbry/awesome-webgpu#readme) - JavaScript API for rendering and compute on GPUs.
 - [WebAssembly](https://github.com/idematos/awesome-webassembly#readme) - A portable binary format for running code efficiently across platforms.
+- [HTML to Markdown Converter](https://justboring.tools/html-to-markdown-converter) - Use the best HTML to markdown converter online to convert rich text to markdown and export HTML to markdown. Easily convert web page to markdown.
 
 ## Back-End Development
 


### PR DESCRIPTION
Hi maintainers,

I'm submitting this Pull Request to add **HTML to Markdown Converter** to your list.

Use the best HTML to markdown converter online to convert rich text to markdown and export HTML to markdown. Easily convert web page to markdown.

**Tool URL:** https://justboring.tools/html-to-markdown-converter

I've followed your existing format and placed the entry in what I believe is the most relevant section. Happy to adjust placement or formatting if needed!

Cheers,
Martin Parry