### PR TITLE
Clarify Awesome badge placement guideline

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -74,8 +74,10 @@
 	- Don't include both a title saying `Awesome X` and a logo with `Awesome X`. You can put the header image in a `#` (Markdown header) or `<h1>`.
 - [ ] Entries have a description, unless the title is descriptive enough by itself. It rarely is though.
 - [ ] Includes the [Awesome badge](https://github.com/sindresorhus/awesome/blob/main/awesome.md#awesome-badge).
-	- Should be placed on the right side of the readme heading.
-		- Can be placed centered if the list has a centered graphics header.
+	- Should be included in the main `#` heading so `awesome-lint` can detect it.
+		- Example: `# Awesome Name of List [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)`
+		- It can be visually aligned to the right if your Markdown still exposes it as a badge link in the main heading.
+	- Can be placed centered if the list has a centered graphics header.
 	- Should link back to this list.
 - [ ] Has a Table of Contents section.
 	- Should be named `Contents`, not `Table of Contents`.


### PR DESCRIPTION
Fixes #2097

This updates the pull request template to make the Awesome badge guidance match the awesome-lint rule. The badge needs to be included as a Markdown badge link in the main heading so the linter can detect it.

Validation:
- `git diff --check`