### PR TITLE
Harden CI lint workflow (supply-chain, untrusted clone, least privilege)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,16 @@
+name: Lint
 on:
   pull_request:
     branches: [main]
     paths:
       - 'readme.md'
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
       - name: awesome-lint

--- a/.github/workflows/repo_linter.sh
+++ b/.github/workflows/repo_linter.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -eo pipefail
 
-# Find the repo in the git diff and then set it to an env variables.
+# Pin awesome-lint to a verified version (avoid pulling an arbitrary/compromised release at CI time).
+AWESOME_LINT_VERSION="3.0.0"
+
+# Find the repo in the git diff and then set it to an env variable.
 REPO_TO_LINT=$(
 	git diff origin/main -- readme.md |
 	# Look for changes (indicated by lines starting with +).
@@ -14,10 +17,19 @@ REPO_TO_LINT=$(
 # If there's no repo found, exit quietly.
 if [ -z "$REPO_TO_LINT" ]; then
 	echo "No new link found in the format:  https://....#readme"
-else
-	echo "Cloning $REPO_TO_LINT"
-	mkdir -p cloned
-	cd cloned
-	git clone "$REPO_TO_LINT" .
-	npx awesome-lint
+	exit 0
 fi
+
+# Only accept canonical GitHub repo URLs (anti-injection: reject anything else).
+if ! [[ "$REPO_TO_LINT" =~ ^https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/?$ ]]; then
+	echo "::error::Refused URL (expected https://github.com/owner/repo): $REPO_TO_LINT"
+	exit 1
+fi
+
+echo "Cloning $REPO_TO_LINT"
+mkdir -p cloned
+cd cloned
+# Isolate the untrusted clone: no hooks executed, no tags, shallow.
+GIT_ALLOW_PROTOCOL=https \
+git -c core.hooksPath=/dev/null clone --depth 1 --no-tags "$REPO_TO_LINT" .
+npx "awesome-lint@${AWESOME_LINT_VERSION}"

--- a/.github/workflows/repo_linter.sh
+++ b/.github/workflows/repo_linter.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 # Pin awesome-lint to a verified version (avoid pulling an arbitrary/compromised release at CI time).
-AWESOME_LINT_VERSION="3.0.0"
+AWESOME_LINT_VERSION="2.3.0"
 
 # Find the repo in the git diff and then set it to an env variable.
 REPO_TO_LINT=$(


### PR DESCRIPTION
This hardens the PR-lint CI, which clones and lints contributor-supplied (untrusted) repositories.

### Changes
- **Pin `awesome-lint`** to a fixed version instead of `npx awesome-lint` (avoids pulling an arbitrary/compromised release at CI time).
- **Isolate the untrusted clone**: run `git clone` with `core.hooksPath=/dev/null` (no hooks executed), `--no-tags`, `--depth 1`, and `GIT_ALLOW_PROTOCOL=https`.
- **Validate the extracted URL**: only accept `https://github.com/owner/repo` before cloning.
- **Least-privilege token**: add `permissions: contents: read`.
- **Pin `actions/checkout`** to a commit SHA (`df4cb1c…`, v6).

### Notes
The job runs on `pull_request` (not `pull_request_target`), so secrets are not exposed; the residual risk addressed here is arbitrary code execution on the runner via a malicious contributor repo. No behavior change for legitimate list submissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)