### PR TITLE
Fix separator in Transit entry

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -784,7 +784,7 @@
 - [OpenGL](https://github.com/eug/awesome-opengl#readme) - Cross-platform API for rendering 2D and 3D graphics.
 - [GraphQL](https://github.com/chentsulin/awesome-graphql#readme)
 - [Urban & Regional Planning](https://github.com/APA-Technology-Division/urban-and-regional-planning-resources#readme) - Concerning the built environment and communities.
-- [Transit](https://github.com/MobilityData/awesome-transit#readme) – Data standards, APIs, apps, tools, datasets, and research around open source technology of public transit.
+- [Transit](https://github.com/MobilityData/awesome-transit#readme) - Data standards, APIs, apps, tools, datasets, and research around open source technology of public transit.
 - [Research Tools](https://github.com/emptymalei/awesome-research#readme)
 - [Data Visualization](https://github.com/javierluraschi/awesome-dataviz#readme)
 - [Microservices](https://github.com/mfornos/awesome-microservices#readme)


### PR DESCRIPTION
The Transit entry used an en-dash (`–`) to separate the link and description, while every other entry in the list uses a hyphen (`-`). This changes it to a hyphen for consistency and to follow the contribution guideline ("The link and description are separated by a dash").