### PR TITLE
Fix: Prevent repo linter from crashing on deletion-only PRs

### DIFF
--- a/.github/workflows/repo_linter.sh
+++ b/.github/workflows/repo_linter.sh
@@ -5,9 +5,9 @@ set -eo pipefail
 REPO_TO_LINT=$(
 	git diff origin/main -- readme.md |
 	# Look for changes (indicated by lines starting with +).
-	grep ^+ |
+	(grep ^+ || true) |
 	# Get the line that includes the readme.
-	grep -Eo 'https.*#readme' |
+	(grep -Eo 'https.*#readme' || true) |
 	# Get just the URL.
 	sed 's/#readme//')
 


### PR DESCRIPTION
Hi @sindresorhus,

I noticed that the CI workflow `lint (pull_request)` fails and crashes on Pull Requests that only remove links (such as housekeeping PRs). 

### The Issue
In `.github/workflows/repo_linter.sh`, the script enforces `set -eo pipefail`. When a PR does not add any new links (i.e., the diff has no `+` lines), the `grep ^+` command finds no matches and immediately exits with code `1`. Due to `pipefail`, this instantly aborts the bash script before it can reach the graceful exit condition:

```bash
if [ -z "$REPO_TO_LINT" ]; then
	echo "No new link found in the format:  https://....#readme"
```

### The Fix
This PR wraps the `grep` commands in subshells with an `|| true` fallback `(grep ^+ || true)`. This ensures that if no lines are added, `grep` will not trigger an early exit via `pipefail`, allowing the script to proceed and gracefully print the "No new link found" message as originally intended.

I have tested this fix locally to ensure the exit code remains `0` when no new links are present in the diff.

Best regards,
Subba Reddy Palagiri