### PR TITLE
Add awesome-pentest to Security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -622,6 +622,7 @@
 - [Annual Security Reports](https://github.com/jacobdjwilson/awesome-annual-security-reports#readme) - Exploring cybersecurity trends, insights, and challenges.
 - [CI/CD Attacks](https://github.com/TupleType/awesome-cicd-attacks#readme) - Offensive research of systems and processes related to developing and deploying code.
 - [OpenID Connect](https://github.com/cerberauth/awesome-openid-connect#readme) - Identity standard and authentication protocol built on OAuth 2.0 for user identity assertion.
+- [Pentest](https://github.com/enaqx/awesome-pentest#readme) - A collection of awesome penetration testing resources, tools and other shiny things.
 
 ## Content Management Systems
 


### PR DESCRIPTION
Adds `enaqx/awesome-pentest` to the Security section.

It's a popular curated list of penetration testing resources, tools and other shiny things. Currently maintained with 26K+ stars and recent activity.

- Alphabetically placed at end of the Security section
- Description formatted consistently with siblings
- Single line addition with link + brief description ending in period