### PR TITLE
Add daily.dev to Awesome lists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -884,3 +884,4 @@
 - [StumbleUponAwesome](https://github.com/basharovV/StumbleUponAwesome) - Discover random pages from the Awesome dataset using a browser extension.
 - [Awesome CLI](https://github.com/umutphp/awesome-cli) - A simple command-line tool to dive into Awesome lists.
 - [Track Awesome List](https://www.trackawesomelist.com) - View the latest updates of Awesome lists.
+- [daily.dev](https://daily.dev) - Developer news and learning platform.


### PR DESCRIPTION
This PR adds daily.dev, a developer news and learning platform, to the awesome list.
