### PR TITLE
Add Cybersecurity Datasets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -607,6 +607,7 @@
 - [Web Security](https://github.com/qazbnm456/awesome-web-security#readme) - Security of web apps & services.
 - [Lockpicking](https://github.com/fabacab/awesome-lockpicking#readme) - The art of unlocking a lock by manipulating its components without the key.
 - [Cybersecurity Blue Team](https://github.com/fabacab/awesome-cybersecurity-blueteam#readme) - Groups of individuals who identify security flaws in information technology systems.
+- [Cybersecurity Datasets](https://github.com/jordanricky1604-ship-it/Awesome-Cybersecurity-Datasets#readme) - Curated list of modern cybersecurity datasets for threat research and LLM security.
 - [Fuzzing](https://github.com/cpuu/awesome-fuzzing#readme) - Automated software testing technique that involves feeding pseudo-randomly generated input data.
 - [Embedded and IoT Security](https://github.com/fkie-cad/awesome-embedded-and-iot-security#readme)
 - [GDPR](https://github.com/bakke92/awesome-gdpr#readme) - Regulation on data protection and privacy for all individuals within EU.


### PR DESCRIPTION
I'm submitting a highly maintained, state-of-the-art fork and continuation of the previously abandoned cybersecurity datasets list. It has been completely revamped for 2026 with critical modern additions like LLM Jailbreak datasets, cloud-native (AWS/Azure) telemetry, and modern malware catalogs.

- [x] I have read the [contribution guidelines](https://github.com/sindresorhus/awesome/blob/main/contributing.md).
- [x] The list has an appropriate \wesome\ badge.
- [x] The list is organized and well-formatted.